### PR TITLE
Add support for 2FA via e-mail

### DIFF
--- a/custom_components/engie_be/const.py
+++ b/custom_components/engie_be/const.py
@@ -21,9 +21,14 @@ OAUTH_AUDIENCE = "customer"
 
 # Config entry keys (beyond homeassistant.const CONF_USERNAME / CONF_PASSWORD)
 CONF_CUSTOMER_NUMBER = "customer_number"
+CONF_MFA_METHOD = "mfa_method"
 CONF_CLIENT_ID = "client_id"
 CONF_ACCESS_TOKEN = "access_token"  # noqa: S105
 CONF_REFRESH_TOKEN = "refresh_token"  # noqa: S105
+
+# MFA method options
+MFA_METHOD_SMS = "sms"
+MFA_METHOD_EMAIL = "email"
 
 # EAN prefix for energy type detection
 GAS_EAN_PREFIX = "5414488600"

--- a/custom_components/engie_be/translations/en.json
+++ b/custom_components/engie_be/translations/en.json
@@ -2,20 +2,28 @@
     "config": {
         "step": {
             "user": {
-                "description": "Enter your ENGIE Belgium account credentials and customer number. A verification code will be sent to your registered phone number via SMS.",
+                "description": "Enter your ENGIE Belgium account credentials and customer number, and choose your preferred two-factor authentication method.",
                 "data": {
                     "username": "Email address",
                     "password": "Password",
                     "customer_number": "Customer number",
-                    "client_id": "Client ID"
+                    "client_id": "Client ID",
+                    "mfa_method": "Two-factor authentication method"
                 },
                 "data_description": {
                     "customer_number": "Your ENGIE Belgium customer/business agreement number.",
-                    "client_id": "OAuth client ID. Only change this if you know what you are doing."
+                    "client_id": "OAuth client ID. Only change this if you know what you are doing.",
+                    "mfa_method": "Choose how you want to receive your verification code."
                 }
             },
-            "mfa": {
+            "mfa_sms": {
                 "description": "Enter the 6-digit verification code that was sent to your phone via SMS.",
+                "data": {
+                    "code": "Verification code"
+                }
+            },
+            "mfa_email": {
+                "description": "Enter the 6-digit verification code that was sent to your email address.",
                 "data": {
                     "code": "Verification code"
                 }


### PR DESCRIPTION
This pull request adds support for email-based two-factor authentication (MFA) in addition to the existing SMS-based MFA for the ENGIE Belgium integration. Users can now choose their preferred MFA method (SMS or email) during setup, and the authentication flow and configuration UI have been updated accordingly to handle both options.

**MFA method selection and configuration:**

* Added a new configuration option `mfa_method` to allow users to select between SMS and email for two-factor authentication during setup (`const.py`, `config_flow.py`, `translations/en.json`). [[1]](diffhunk://#diff-1bb249f0061c39e0cc72b0db98a37d3f90464989950ca181268841c42c777e1fR24-R32) [[2]](diffhunk://#diff-0c45b767096d72659ae535e4ce4e00fff3ae9fca4318cfdd8d9e9d75bd594687R134-R198) [[3]](diffhunk://#diff-0d555b3522844567561605378ab32eb5708f04165ad6f6fab48e2e682def9480L5-R29)

**Authentication flow changes:**

* Refactored the authentication flow in `api.py` to support both SMS and email MFA methods, including splitting the challenge state to a generic `mfa_challenge_state` and implementing separate submission and challenge triggers for each method. [[1]](diffhunk://#diff-01477676f94fa026e5488e0afe7e6b559bc299a63cd59d7802792ed6d848e066L60-R61) [[2]](diffhunk://#diff-01477676f94fa026e5488e0afe7e6b559bc299a63cd59d7802792ed6d848e066R142-R156) [[3]](diffhunk://#diff-01477676f94fa026e5488e0afe7e6b559bc299a63cd59d7802792ed6d848e066R275-R283) [[4]](diffhunk://#diff-01477676f94fa026e5488e0afe7e6b559bc299a63cd59d7802792ed6d848e066L381-R440) [[5]](diffhunk://#diff-01477676f94fa026e5488e0afe7e6b559bc299a63cd59d7802792ed6d848e066R541-R669)

**Configuration UI improvements:**

* Updated the config flow to present a dropdown for MFA method selection, and split the MFA code entry step into separate flows for SMS and email, with corresponding user prompts and error handling. [[1]](diffhunk://#diff-0c45b767096d72659ae535e4ce4e00fff3ae9fca4318cfdd8d9e9d75bd594687L57-R60) [[2]](diffhunk://#diff-0c45b767096d72659ae535e4ce4e00fff3ae9fca4318cfdd8d9e9d75bd594687R80) [[3]](diffhunk://#diff-0c45b767096d72659ae535e4ce4e00fff3ae9fca4318cfdd8d9e9d75bd594687L88-R95) [[4]](diffhunk://#diff-0c45b767096d72659ae535e4ce4e00fff3ae9fca4318cfdd8d9e9d75bd594687R209) [[5]](diffhunk://#diff-0c45b767096d72659ae535e4ce4e00fff3ae9fca4318cfdd8d9e9d75bd594687L185-R244) [[6]](diffhunk://#diff-0d555b3522844567561605378ab32eb5708f04165ad6f6fab48e2e682def9480L5-R29)

**Translation and documentation updates:**

* Revised English translations to describe the new MFA method choice and provide clear instructions for both SMS and email verification code entry.

**Internal constants and imports:**

* Added constants for the new MFA method options and updated imports to support the changes throughout the codebase. [[1]](diffhunk://#diff-1bb249f0061c39e0cc72b0db98a37d3f90464989950ca181268841c42c777e1fR24-R32) [[2]](diffhunk://#diff-0c45b767096d72659ae535e4ce4e00fff3ae9fca4318cfdd8d9e9d75bd594687R26-R35)
