### PR TITLE
Do not reload config entry on token rotation

### DIFF
--- a/custom_components/engie_be/__init__.py
+++ b/custom_components/engie_be/__init__.py
@@ -49,6 +49,7 @@ async def async_setup_entry(
     entry.runtime_data = EngieBeData(
         client=client,
         coordinator=coordinator,
+        last_options=dict(entry.options),
     )
 
     # Do an initial token refresh so we have a valid access token
@@ -101,8 +102,9 @@ async def async_reload_entry(
     hass: HomeAssistant,
     entry: EngieBeConfigEntry,
 ) -> None:
-    """Reload config entry."""
-    await hass.config_entries.async_reload(entry.entry_id)
+    """Reload config entry only when options change (not on token rotation)."""
+    if dict(entry.options) != entry.runtime_data.last_options:
+        await hass.config_entries.async_reload(entry.entry_id)
 
 
 def _persist_tokens(

--- a/custom_components/engie_be/data.py
+++ b/custom_components/engie_be/data.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -22,3 +22,4 @@ class EngieBeData:
     client: EngieBeApiClient
     coordinator: EngieBeDataUpdateCoordinator
     authenticated: bool = field(default=False)
+    last_options: dict[str, Any] = field(default_factory=dict)


### PR DESCRIPTION
This pull request introduces improvements to how configuration options are tracked and handled for the Engie BE integration. The main change is to ensure that configuration reloads are triggered only when options change, not on token rotation, and to persist the last known options for comparison.

**Config reload logic improvements:**

* Updated the reload logic in `async_reload_entry` to only trigger a reload if the configuration options have changed, preventing unnecessary reloads on token rotation.

**Tracking and persisting options:**

* Added a `last_options` field to the `EngieBeData` dataclass to store the last known configuration options for comparison.
* When setting up the entry in `async_setup_entry`, the current options are stored in the new `last_options` field.

**Type and import updates:**

* Extended the type import in `data.py` to include `Any` for the new `last_options` field.