### PR TITLE
Improve customer number input field

### DIFF
--- a/custom_components/engie_be/config_flow.py
+++ b/custom_components/engie_be/config_flow.py
@@ -94,6 +94,10 @@ class EngieBeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     return await self.async_step_mfa_email()
                 return await self.async_step_mfa_sms()
 
+        customer_default = (user_input or {}).get(CONF_CUSTOMER_NUMBER, vol.UNDEFINED)
+        if isinstance(customer_default, str):
+            customer_default = customer_default.removeprefix("00")
+
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema(
@@ -113,12 +117,11 @@ class EngieBeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     ),
                     vol.Required(
                         CONF_CUSTOMER_NUMBER,
-                        default=(user_input or {}).get(
-                            CONF_CUSTOMER_NUMBER, vol.UNDEFINED
-                        ),
+                        default=customer_default,
                     ): selector.TextSelector(
                         selector.TextSelectorConfig(
                             type=selector.TextSelectorType.TEXT,
+                            prefix="00",
                         ),
                     ),
                     vol.Required(
@@ -231,7 +234,9 @@ class EngieBeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     data={
                         CONF_USERNAME: self._user_input[CONF_USERNAME],
                         CONF_PASSWORD: self._user_input[CONF_PASSWORD],
-                        CONF_CUSTOMER_NUMBER: self._user_input[CONF_CUSTOMER_NUMBER],
+                        CONF_CUSTOMER_NUMBER: (
+                            f"00{self._user_input[CONF_CUSTOMER_NUMBER]}"
+                        ),
                         CONF_CLIENT_ID: self._user_input.get(
                             CONF_CLIENT_ID, DEFAULT_CLIENT_ID
                         ),

--- a/custom_components/engie_be/strings.json
+++ b/custom_components/engie_be/strings.json
@@ -11,7 +11,7 @@
                     "mfa_method": "Two-factor authentication method"
                 },
                 "data_description": {
-                    "customer_number": "Your ENGIE Belgium customer/business agreement number.",
+                    "customer_number": "Your ENGIE Belgium customer number as shown in the ENGIE Smart app.",
                     "client_id": "OAuth client ID. Only change this if you know what you are doing.",
                     "mfa_method": "Choose how you want to receive your verification code."
                 }

--- a/custom_components/engie_be/translations/en.json
+++ b/custom_components/engie_be/translations/en.json
@@ -11,7 +11,7 @@
                     "mfa_method": "Two-factor authentication method"
                 },
                 "data_description": {
-                    "customer_number": "Your ENGIE Belgium customer/business agreement number.",
+                    "customer_number": "Your ENGIE Belgium customer number as shown in the ENGIE Smart app.",
                     "client_id": "OAuth client ID. Only change this if you know what you are doing.",
                     "mfa_method": "Choose how you want to receive your verification code."
                 }


### PR DESCRIPTION
This pull request updates how the ENGIE Belgium customer number is handled in the configuration flow, ensuring a consistent format and improving clarity for users. The main changes involve normalizing the customer number input, updating the UI to guide users, and revising related help text.

**Customer Number Input Normalization:**

* Strips the `"00"` prefix from user input for `CONF_CUSTOMER_NUMBER` during form display, and adds it back when sending data to the API, ensuring the internal format is always correct. [[1]](diffhunk://#diff-0c45b767096d72659ae535e4ce4e00fff3ae9fca4318cfdd8d9e9d75bd594687R97-R100) [[2]](diffhunk://#diff-0c45b767096d72659ae535e4ce4e00fff3ae9fca4318cfdd8d9e9d75bd594687L234-R239)

**UI Improvements:**

* Sets `"00"` as a prefix in the text selector for the customer number field, guiding users to enter the number as expected.

**Help Text Updates:**

* Updates the customer number description in both `strings.json` and English translations to clarify that the number should be entered as shown in the ENGIE Smart app.