### PR TITLE
Feat: Derive energy type from service-points endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ data from the ENGIE Belgium API and exposes it as sensors.
 - Authenticates via ENGIE Belgium's OAuth2/PKCE flow with two-factor
   authentication (SMS or email)
 - Automatically refreshes access tokens in the background
-- Detects gas and electricity contracts from your EAN numbers
+- Detects gas and electricity contracts via the ENGIE service-points endpoint
 - Creates price sensors per energy type, direction (offtake / injection), and
   tariff rate (single-rate or peak / off-peak for dual-rate contracts)
 - Configurable update interval via the integration options
@@ -127,8 +127,10 @@ After setup, you can configure the price update interval:
   and persisted to the config entry.
 - **Data polling**: Energy prices are fetched at the configured interval
   (default: every hour). The coordinator makes a single API call per update.
-- **Energy type detection**: The EAN prefix determines whether a contract is
-  gas (`5414488600*`) or electricity (`5414488200*`).
+- **Energy type detection**: At startup the integration calls the ENGIE
+  service-points endpoint for each EAN to determine whether the contract is gas
+  or electricity. If the lookup fails, a generic "Energy" label is used as
+  fallback.
 
 ## License
 

--- a/custom_components/engie_be/__init__.py
+++ b/custom_components/engie_be/__init__.py
@@ -84,6 +84,25 @@ async def async_setup_entry(
 
     # Fetch initial data and forward platforms
     await coordinator.async_config_entry_first_refresh()
+
+    # Resolve energy type for each EAN via the service-points API
+    service_points: dict[str, str] = {}
+    for item in (coordinator.data or {}).get("items", []):
+        ean: str = item.get("ean", "")
+        if not ean:
+            continue
+        try:
+            sp_data = await client.async_get_service_point(ean)
+            division: str = sp_data.get("division", "")
+            if division:
+                service_points[ean] = division
+                LOGGER.debug("Service-point %s: division=%s", ean, division)
+        except EngieBeApiClientError:
+            LOGGER.warning(
+                "Failed to fetch service-point for EAN %s; using fallback", ean
+            )
+    entry.runtime_data.service_points = service_points
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 

--- a/custom_components/engie_be/api.py
+++ b/custom_components/engie_be/api.py
@@ -20,6 +20,7 @@ from .const import (
     MFA_METHOD_SMS,
     OAUTH_AUDIENCE,
     OAUTH_SCOPES,
+    PREMISES_BASE_URL,
     REDIRECT_URI,
     USER_AGENT_BROWSER,
     USER_AGENT_NATIVE,
@@ -260,6 +261,27 @@ class EngieBeApiClient:
             url=url,
             headers=headers,
             params={"maxGranularity": "MONTHLY"},
+            json_response=True,
+        )
+
+    async def async_get_service_point(self, ean: str) -> dict[str, Any]:
+        """
+        Fetch service-point metadata for a single EAN.
+
+        Returns the parsed JSON response which includes a ``division``
+        field (``"ELECTRICITY"`` or ``"GAS"``).
+        """
+        url = f"{PREMISES_BASE_URL}/service-points/{ean}"
+        headers = {
+            "User-Agent": USER_AGENT_BROWSER,
+            "Accept": "application/json, application/problem+json",
+            "authorization": f"Bearer {self.access_token}",
+        }
+        return await self._api_wrapper(
+            session=self._session,
+            method="GET",
+            url=url,
+            headers=headers,
             json_response=True,
         )
 

--- a/custom_components/engie_be/const.py
+++ b/custom_components/engie_be/const.py
@@ -12,6 +12,7 @@ ATTRIBUTION = "Data provided by ENGIE Belgium"
 # OAuth / Auth0 endpoints
 AUTH_BASE_URL = "https://account.engie.be"
 API_BASE_URL = "https://www.engie.be/api/engie/be/ms/billing/customer/v1"
+PREMISES_BASE_URL = "https://www.engie.be/api/engie/be/ms/premises/customer/v1"
 
 # OAuth configuration (public mobile-app client, no secret needed)
 DEFAULT_CLIENT_ID = "R0PQyUdjO5B2tBaRnltgitVnnUmjGyld"
@@ -29,10 +30,6 @@ CONF_REFRESH_TOKEN = "refresh_token"  # noqa: S105
 # MFA method options
 MFA_METHOD_SMS = "sms"
 MFA_METHOD_EMAIL = "email"
-
-# EAN prefix for energy type detection
-GAS_EAN_PREFIX = "5414488600"
-ELECTRICITY_EAN_PREFIX = "5414488200"
 
 # User-Agent strings matching the ENGIE mobile app
 USER_AGENT_BROWSER = (

--- a/custom_components/engie_be/data.py
+++ b/custom_components/engie_be/data.py
@@ -23,3 +23,4 @@ class EngieBeData:
     coordinator: EngieBeDataUpdateCoordinator
     authenticated: bool = field(default=False)
     last_options: dict[str, Any] = field(default_factory=dict)
+    service_points: dict[str, str] = field(default_factory=dict)

--- a/custom_components/engie_be/sensor.py
+++ b/custom_components/engie_be/sensor.py
@@ -11,11 +11,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 
-from .const import (
-    ELECTRICITY_EAN_PREFIX,
-    GAS_EAN_PREFIX,
-    LOGGER,
-)
+from .const import LOGGER
 from .entity import EngieBeEntity
 
 if TYPE_CHECKING:
@@ -26,13 +22,17 @@ if TYPE_CHECKING:
     from .data import EngieBeConfigEntry
 
 
-def _detect_energy_type(ean: str) -> str:
-    """Detect the energy type from the EAN prefix."""
-    if ean.startswith(GAS_EAN_PREFIX):
-        return "Gas"
-    if ean.startswith(ELECTRICITY_EAN_PREFIX):
-        return "Electricity"
-    return ean
+# Mapping from service-point division to display name.
+_DIVISION_MAP: dict[str, str] = {
+    "ELECTRICITY": "Electricity",
+    "GAS": "Gas",
+}
+
+
+def _detect_energy_type(ean: str, service_points: dict[str, str]) -> str:
+    """Detect the energy type from the service-points division lookup."""
+    division = service_points.get(ean, "")
+    return _DIVISION_MAP.get(division, "Energy")
 
 
 def _find_current_price(prices: list[dict[str, Any]]) -> dict[str, Any] | None:
@@ -67,6 +67,7 @@ def _slot_suffixes(slot_code: str) -> tuple[str, str]:
 
 def _build_sensor_descriptions(
     data: dict[str, Any],
+    service_points: dict[str, str],
 ) -> list[tuple[SensorEntityDescription, str, str, str]]:
     """
     Build sensor descriptions from the API response.
@@ -79,7 +80,7 @@ def _build_sensor_descriptions(
 
     for item in data.get("items", []):
         ean: str = item.get("ean", "unknown")
-        energy_type = _detect_energy_type(ean)
+        energy_type = _detect_energy_type(ean, service_points)
         # Strip trailing _ID* suffix for display
         # e.g. "541448...267_ID1" -> cleaner key
         ean_short = ean.split("_", maxsplit=1)[0] if "_" in ean else ean
@@ -154,7 +155,9 @@ async def async_setup_entry(
         LOGGER.warning("No data available yet, skipping sensor setup")
         return
 
-    sensor_defs = _build_sensor_descriptions(coordinator.data)
+    sensor_defs = _build_sensor_descriptions(
+        coordinator.data, entry.runtime_data.service_points
+    )
     async_add_entities(
         EngieBeEnergySensor(
             coordinator=coordinator,

--- a/custom_components/engie_be/strings.json
+++ b/custom_components/engie_be/strings.json
@@ -107,6 +107,42 @@
             },
             "electricity_injection_offpeak_excl_vat": {
                 "name": "Electricity off-peak injection price (excl. VAT)"
+            },
+            "energy_offtake": {
+                "name": "Energy offtake price"
+            },
+            "energy_offtake_excl_vat": {
+                "name": "Energy offtake price (excl. VAT)"
+            },
+            "energy_offtake_peak": {
+                "name": "Energy peak offtake price"
+            },
+            "energy_offtake_peak_excl_vat": {
+                "name": "Energy peak offtake price (excl. VAT)"
+            },
+            "energy_offtake_offpeak": {
+                "name": "Energy off-peak offtake price"
+            },
+            "energy_offtake_offpeak_excl_vat": {
+                "name": "Energy off-peak offtake price (excl. VAT)"
+            },
+            "energy_injection": {
+                "name": "Energy injection price"
+            },
+            "energy_injection_excl_vat": {
+                "name": "Energy injection price (excl. VAT)"
+            },
+            "energy_injection_peak": {
+                "name": "Energy peak injection price"
+            },
+            "energy_injection_peak_excl_vat": {
+                "name": "Energy peak injection price (excl. VAT)"
+            },
+            "energy_injection_offpeak": {
+                "name": "Energy off-peak injection price"
+            },
+            "energy_injection_offpeak_excl_vat": {
+                "name": "Energy off-peak injection price (excl. VAT)"
             }
         },
         "binary_sensor": {

--- a/custom_components/engie_be/translations/en.json
+++ b/custom_components/engie_be/translations/en.json
@@ -107,6 +107,42 @@
             },
             "electricity_injection_offpeak_excl_vat": {
                 "name": "Electricity off-peak injection price (excl. VAT)"
+            },
+            "energy_offtake": {
+                "name": "Energy offtake price"
+            },
+            "energy_offtake_excl_vat": {
+                "name": "Energy offtake price (excl. VAT)"
+            },
+            "energy_offtake_peak": {
+                "name": "Energy peak offtake price"
+            },
+            "energy_offtake_peak_excl_vat": {
+                "name": "Energy peak offtake price (excl. VAT)"
+            },
+            "energy_offtake_offpeak": {
+                "name": "Energy off-peak offtake price"
+            },
+            "energy_offtake_offpeak_excl_vat": {
+                "name": "Energy off-peak offtake price (excl. VAT)"
+            },
+            "energy_injection": {
+                "name": "Energy injection price"
+            },
+            "energy_injection_excl_vat": {
+                "name": "Energy injection price (excl. VAT)"
+            },
+            "energy_injection_peak": {
+                "name": "Energy peak injection price"
+            },
+            "energy_injection_peak_excl_vat": {
+                "name": "Energy peak injection price (excl. VAT)"
+            },
+            "energy_injection_offpeak": {
+                "name": "Energy off-peak injection price"
+            },
+            "energy_injection_offpeak_excl_vat": {
+                "name": "Energy off-peak injection price (excl. VAT)"
             }
         },
         "binary_sensor": {


### PR DESCRIPTION
This pull request updates the ENGIE Belgium Home Assistant integration to improve energy type detection by querying the ENGIE service-points API instead of relying on EAN number prefixes. This makes the detection of gas and electricity contracts more robust and accurate. The changes also update the codebase and documentation to reflect this new approach, and add fallback handling and new sensor translation strings for generic "Energy" types.

**Energy type detection improvements:**

* The integration now determines whether a contract is gas or electricity by calling the ENGIE service-points API for each EAN, rather than using EAN number prefixes. If the lookup fails, a generic "Energy" label is used as a fallback. (`custom_components/engie_be/__init__.py`, `custom_components/engie_be/api.py`, `custom_components/engie_be/const.py`, `custom_components/engie_be/data.py`, `custom_components/engie_be/sensor.py`, [[1]](diffhunk://#diff-c342ea38aa40cd5705e1b40f2d535b353d1dd3338ff19bba42f55508da8deec0R87-R105) [[2]](diffhunk://#diff-01477676f94fa026e5488e0afe7e6b559bc299a63cd59d7802792ed6d848e066R267-R287) [[3]](diffhunk://#diff-1bb249f0061c39e0cc72b0db98a37d3f90464989950ca181268841c42c777e1fR15) [[4]](diffhunk://#diff-7e7239e9fa7eed2068bf66b28e68b5fef786c49af7f4c5cf1a6e72af2216b0c2R26) [[5]](diffhunk://#diff-815756524ffae2c249f15ccb2cfd50ecf3064808aa313c0d3c934c73e3b754daL29-R35) [[6]](diffhunk://#diff-815756524ffae2c249f15ccb2cfd50ecf3064808aa313c0d3c934c73e3b754daR70) [[7]](diffhunk://#diff-815756524ffae2c249f15ccb2cfd50ecf3064808aa313c0d3c934c73e3b754daL82-R83) [[8]](diffhunk://#diff-815756524ffae2c249f15ccb2cfd50ecf3064808aa313c0d3c934c73e3b754daL157-R160)

* Removed the old EAN prefix-based detection logic and associated constants, simplifying the code and reducing the risk of misclassification. (`custom_components/engie_be/const.py`, `custom_components/engie_be/sensor.py`, [[1]](diffhunk://#diff-1bb249f0061c39e0cc72b0db98a37d3f90464989950ca181268841c42c777e1fL33-L36) [[2]](diffhunk://#diff-815756524ffae2c249f15ccb2cfd50ecf3064808aa313c0d3c934c73e3b754daL14-R14) [[3]](diffhunk://#diff-815756524ffae2c249f15ccb2cfd50ecf3064808aa313c0d3c934c73e3b754daL29-R35)

**Documentation updates:**

* Updated the `README.md` to describe the new energy type detection method using the service-points endpoint, and clarified fallback behavior. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R16) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L130-R133)

**Translation and UI improvements:**

* Added new translation strings for generic "Energy" sensors to support cases where the energy type cannot be determined. (`custom_components/engie_be/strings.json`, `custom_components/engie_be/translations/en.json`, [custom_components/engie_be/strings.jsonR110-R145](diffhunk://#diff-0d1d4e699f6ecf6e7b821bee4ce0c8c3c230cfcfafa5fdc7850b6bef369c1269R110-R145))

These changes make the integration more reliable and user-friendly, especially for users with non-standard EANs or contracts.