### PR TITLE
Fix customer number whitespace causing API 400 errors

### DIFF
--- a/custom_components/engie_be/api.py
+++ b/custom_components/engie_be/api.py
@@ -248,7 +248,7 @@ class EngieBeApiClient:
         """
         url = (
             f"{API_BASE_URL}/business-agreements/"
-            f"{customer_number}/supplier-energy-prices"
+            f"{customer_number.replace(' ', '')}/supplier-energy-prices"
         )
         headers = {
             "User-Agent": USER_AGENT_BROWSER,

--- a/custom_components/engie_be/config_flow.py
+++ b/custom_components/engie_be/config_flow.py
@@ -226,6 +226,9 @@ class EngieBeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             else:
                 self._auth_flow_state = None
 
+                raw_number = self._user_input[CONF_CUSTOMER_NUMBER]
+                customer_number = f"00{raw_number.replace(' ', '')}"
+
                 await self.async_set_unique_id(slugify(self._user_input[CONF_USERNAME]))
                 self._abort_if_unique_id_configured()
 
@@ -234,9 +237,7 @@ class EngieBeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     data={
                         CONF_USERNAME: self._user_input[CONF_USERNAME],
                         CONF_PASSWORD: self._user_input[CONF_PASSWORD],
-                        CONF_CUSTOMER_NUMBER: (
-                            f"00{self._user_input[CONF_CUSTOMER_NUMBER]}"
-                        ),
+                        CONF_CUSTOMER_NUMBER: customer_number,
                         CONF_CLIENT_ID: self._user_input.get(
                             CONF_CLIENT_ID, DEFAULT_CLIENT_ID
                         ),


### PR DESCRIPTION
## Summary

- Strip spaces from the customer number at config entry creation time in `config_flow.py`, preventing whitespace from being persisted
- Add defense-in-depth whitespace stripping at URL construction time in `api.py`, covering existing config entries that may already have spaces stored

## Problem

When users enter their customer number with spaces, the spaces get URL-encoded as `%20` in the ENGIE API call, resulting in a 400 error.

## Fix

Two-layer approach:
1. **Primary**: Sanitize at storage time (`config_flow.py`) — new config entries will always have a clean customer number
2. **Defense-in-depth**: Sanitize at URL construction time (`api.py`) — existing config entries with spaces already stored will also work without requiring re-configuration