### PR TITLE
Add tri-rate (super off-peak) support

### DIFF
--- a/custom_components/engie_be/sensor.py
+++ b/custom_components/engie_be/sensor.py
@@ -47,21 +47,47 @@ def _find_current_price(prices: list[dict[str, Any]]) -> dict[str, Any] | None:
     return prices[-1] if prices else None
 
 
-# Mapping from API timeOfUseSlotCode to (key_suffix, translation_suffix).
+# Mapping from normalised rate code to (key_suffix, translation_suffix).
 # TOTAL_HOURS uses empty strings to preserve backward compatibility.
-_SLOT_CODE_MAP: dict[str, tuple[str, str]] = {
+# A ``None`` value means "skip this entry entirely" (e.g. blended rates).
+_SLOT_CODE_MAP: dict[str, tuple[str, str] | None] = {
     "TOTAL_HOURS": ("", ""),
     "PEAK": ("_peak", "_peak"),
     "OFFPEAK": ("_offpeak", "_offpeak"),
+    "SUPEROFFPEAK": ("_superoffpeak", "_superoffpeak"),
+    "EN": None,  # blended/total rate — skipped
 }
 
+# Direction keywords used to split prefixed slot codes.
+_DIRECTION_KEYWORDS = ("OFFTAKE_", "INJECTION_")
 
-def _slot_suffixes(slot_code: str) -> tuple[str, str]:
-    """Return (key_suffix, translation_suffix) for a time-of-use slot code."""
-    if slot_code in _SLOT_CODE_MAP:
-        return _SLOT_CODE_MAP[slot_code]
-    # Unknown codes: use lowercased slot code as suffix
-    lower = slot_code.lower()
+
+def _normalize_slot_code(raw_code: str) -> str:
+    """
+    Normalise a raw ``timeOfUseSlotCode`` to its rate portion.
+
+    Bare codes (``TOTAL_HOURS``, ``PEAK``, ``OFFPEAK``) are returned as-is.
+    Prefixed codes (e.g. ``S_TOU1_OFFTAKE_PEAK``) are stripped down to the
+    part after the last direction keyword (``OFFTAKE_`` / ``INJECTION_``).
+    """
+    for keyword in _DIRECTION_KEYWORDS:
+        idx = raw_code.rfind(keyword)
+        if idx != -1:
+            return raw_code[idx + len(keyword) :]
+    return raw_code
+
+
+def _slot_suffixes(slot_code: str) -> tuple[str, str] | None:
+    """
+    Return (key_suffix, translation_suffix) for a time-of-use slot code.
+
+    Returns ``None`` when the code should be skipped entirely.
+    """
+    normalised = _normalize_slot_code(slot_code)
+    if normalised in _SLOT_CODE_MAP:
+        return _SLOT_CODE_MAP[normalised]
+    # Unknown codes: use lowercased normalised code as suffix
+    lower = normalised.lower()
     return (f"_{lower}", f"_{lower}")
 
 
@@ -103,7 +129,10 @@ def _build_sensor_descriptions(
 
             for slot_entry in direction_list:
                 slot_code: str = slot_entry.get("timeOfUseSlotCode", "TOTAL_HOURS")
-                key_suffix, trans_suffix = _slot_suffixes(slot_code)
+                suffixes = _slot_suffixes(slot_code)
+                if suffixes is None:
+                    continue
+                key_suffix, trans_suffix = suffixes
 
                 base_key = f"{ean_short}_{direction}{key_suffix}"
                 base_trans = f"{energy_type.lower()}_{direction}{trans_suffix}"

--- a/custom_components/engie_be/strings.json
+++ b/custom_components/engie_be/strings.json
@@ -60,18 +60,6 @@
             "gas_offtake_excl_vat": {
                 "name": "Gas offtake price (excl. VAT)"
             },
-            "gas_offtake_peak": {
-                "name": "Gas peak offtake price"
-            },
-            "gas_offtake_peak_excl_vat": {
-                "name": "Gas peak offtake price (excl. VAT)"
-            },
-            "gas_offtake_offpeak": {
-                "name": "Gas off-peak offtake price"
-            },
-            "gas_offtake_offpeak_excl_vat": {
-                "name": "Gas off-peak offtake price (excl. VAT)"
-            },
             "electricity_offtake": {
                 "name": "Electricity offtake price"
             },
@@ -89,6 +77,12 @@
             },
             "electricity_offtake_offpeak_excl_vat": {
                 "name": "Electricity off-peak offtake price (excl. VAT)"
+            },
+            "electricity_offtake_superoffpeak": {
+                "name": "Electricity super off-peak offtake price"
+            },
+            "electricity_offtake_superoffpeak_excl_vat": {
+                "name": "Electricity super off-peak offtake price (excl. VAT)"
             },
             "electricity_injection": {
                 "name": "Electricity injection price"
@@ -108,6 +102,12 @@
             "electricity_injection_offpeak_excl_vat": {
                 "name": "Electricity off-peak injection price (excl. VAT)"
             },
+            "electricity_injection_superoffpeak": {
+                "name": "Electricity super off-peak injection price"
+            },
+            "electricity_injection_superoffpeak_excl_vat": {
+                "name": "Electricity super off-peak injection price (excl. VAT)"
+            },
             "energy_offtake": {
                 "name": "Energy offtake price"
             },
@@ -126,6 +126,12 @@
             "energy_offtake_offpeak_excl_vat": {
                 "name": "Energy off-peak offtake price (excl. VAT)"
             },
+            "energy_offtake_superoffpeak": {
+                "name": "Energy super off-peak offtake price"
+            },
+            "energy_offtake_superoffpeak_excl_vat": {
+                "name": "Energy super off-peak offtake price (excl. VAT)"
+            },
             "energy_injection": {
                 "name": "Energy injection price"
             },
@@ -143,6 +149,12 @@
             },
             "energy_injection_offpeak_excl_vat": {
                 "name": "Energy off-peak injection price (excl. VAT)"
+            },
+            "energy_injection_superoffpeak": {
+                "name": "Energy super off-peak injection price"
+            },
+            "energy_injection_superoffpeak_excl_vat": {
+                "name": "Energy super off-peak injection price (excl. VAT)"
             }
         },
         "binary_sensor": {

--- a/custom_components/engie_be/translations/en.json
+++ b/custom_components/engie_be/translations/en.json
@@ -60,18 +60,6 @@
             "gas_offtake_excl_vat": {
                 "name": "Gas offtake price (excl. VAT)"
             },
-            "gas_offtake_peak": {
-                "name": "Gas peak offtake price"
-            },
-            "gas_offtake_peak_excl_vat": {
-                "name": "Gas peak offtake price (excl. VAT)"
-            },
-            "gas_offtake_offpeak": {
-                "name": "Gas off-peak offtake price"
-            },
-            "gas_offtake_offpeak_excl_vat": {
-                "name": "Gas off-peak offtake price (excl. VAT)"
-            },
             "electricity_offtake": {
                 "name": "Electricity offtake price"
             },
@@ -89,6 +77,12 @@
             },
             "electricity_offtake_offpeak_excl_vat": {
                 "name": "Electricity off-peak offtake price (excl. VAT)"
+            },
+            "electricity_offtake_superoffpeak": {
+                "name": "Electricity super off-peak offtake price"
+            },
+            "electricity_offtake_superoffpeak_excl_vat": {
+                "name": "Electricity super off-peak offtake price (excl. VAT)"
             },
             "electricity_injection": {
                 "name": "Electricity injection price"
@@ -108,6 +102,12 @@
             "electricity_injection_offpeak_excl_vat": {
                 "name": "Electricity off-peak injection price (excl. VAT)"
             },
+            "electricity_injection_superoffpeak": {
+                "name": "Electricity super off-peak injection price"
+            },
+            "electricity_injection_superoffpeak_excl_vat": {
+                "name": "Electricity super off-peak injection price (excl. VAT)"
+            },
             "energy_offtake": {
                 "name": "Energy offtake price"
             },
@@ -126,6 +126,12 @@
             "energy_offtake_offpeak_excl_vat": {
                 "name": "Energy off-peak offtake price (excl. VAT)"
             },
+            "energy_offtake_superoffpeak": {
+                "name": "Energy super off-peak offtake price"
+            },
+            "energy_offtake_superoffpeak_excl_vat": {
+                "name": "Energy super off-peak offtake price (excl. VAT)"
+            },
             "energy_injection": {
                 "name": "Energy injection price"
             },
@@ -143,6 +149,12 @@
             },
             "energy_injection_offpeak_excl_vat": {
                 "name": "Energy off-peak injection price (excl. VAT)"
+            },
+            "energy_injection_superoffpeak": {
+                "name": "Energy super off-peak injection price"
+            },
+            "energy_injection_superoffpeak_excl_vat": {
+                "name": "Energy super off-peak injection price (excl. VAT)"
             }
         },
         "binary_sensor": {


### PR DESCRIPTION
## Summary

- Add support for tri-rate electricity subscriptions (Empower Flextime) that use three time zones: peak, off-peak, and super off-peak
- Normalize prefixed API slot codes (e.g. `S_TOU1_OFFTAKE_PEAK` → `PEAK`) so existing single-rate and dual-rate subscriptions continue to work unchanged
- Skip blended/total rate entries (`EN` slot code) to avoid duplicate sensors

## Background

The ENGIE API returns different `timeOfUseSlotCode` formats depending on the subscription type:

| Subscription | Slot codes |
|---|---|
| Single-rate (gas/electricity) | `TOTAL_HOURS` |
| Dual-rate (day/night) | `PEAK`, `OFFPEAK` |
| Tri-rate (Empower Flextime) | `S_TOU1_OFFTAKE_PEAK`, `S_TOU1_OFFTAKE_OFFPEAK`, `S_TOU1_OFFTAKE_SUPEROFFPEAK`, `S_TOU1_OFFTAKE_EN` |

The new `_normalize_slot_code()` function extracts the rate portion from prefixed codes, allowing all three formats to be handled uniformly.

## Changes

### `sensor.py`
- Added `_normalize_slot_code()` — extracts rate portion from prefixed slot codes by finding the last direction keyword (`OFFTAKE_` / `INJECTION_`)
- Added `SUPEROFFPEAK` to `_SLOT_CODE_MAP` for super off-peak sensors
- Added `EN: None` as a skip sentinel — blended rate entries are skipped entirely
- Updated `_slot_suffixes` return type to `tuple[str, str] | None` and `_build_sensor_descriptions` to handle the `None` skip case

### `strings.json` + `translations/en.json`
- Added 8 super off-peak translation entries (electricity + energy, offtake + injection, incl/excl VAT)
- Removed 4 unused gas TOU entries (peak and off-peak) — gas is always single-rate