### PR TITLE
Feat: silent reauth flow

### DIFF
--- a/custom_components/engie_be/__init__.py
+++ b/custom_components/engie_be/__init__.py
@@ -6,10 +6,15 @@ from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from homeassistant.const import Platform
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.event import async_track_time_interval
 
-from .api import EngieBeApiClient, EngieBeApiClientError
+from .api import (
+    EngieBeApiClient,
+    EngieBeApiClientAuthenticationError,
+    EngieBeApiClientError,
+)
 from .const import (
     CONF_ACCESS_TOKEN,
     CONF_CLIENT_ID,
@@ -85,23 +90,36 @@ async def async_setup_entry(
     # Do an initial token refresh so we have a valid access token
     try:
         new_access, new_refresh = await client.async_refresh_token()
-        _persist_tokens(hass, entry, new_access, new_refresh)
-        entry.runtime_data.authenticated = True
-    except EngieBeApiClientError:
-        LOGGER.warning("Initial token refresh failed; will retry on next interval")
-        entry.runtime_data.authenticated = False
+    except EngieBeApiClientAuthenticationError as err:
+        msg = "Stored ENGIE credentials are no longer valid"
+        raise ConfigEntryAuthFailed(msg) from err
+    except EngieBeApiClientError as err:
+        msg = "Unable to refresh ENGIE access token; will retry"
+        raise ConfigEntryNotReady(msg) from err
+
+    _persist_tokens(hass, entry, new_access, new_refresh)
+    entry.runtime_data.authenticated = True
 
     # Set up recurring token refresh (every 60 seconds)
     async def _refresh_token_callback(_now: object) -> None:
         """Refresh the access token periodically."""
         try:
             new_access, new_refresh = await client.async_refresh_token()
-            _persist_tokens(hass, entry, new_access, new_refresh)
-            entry.runtime_data.authenticated = True
-            LOGGER.debug("Token refreshed successfully")
+        except EngieBeApiClientAuthenticationError:
+            entry.runtime_data.authenticated = False
+            LOGGER.warning(
+                "Scheduled token refresh rejected by ENGIE; starting reauth flow"
+            )
+            entry.async_start_reauth(hass)
+            return
         except EngieBeApiClientError:
             entry.runtime_data.authenticated = False
             LOGGER.warning("Scheduled token refresh failed; will retry")
+            return
+
+        _persist_tokens(hass, entry, new_access, new_refresh)
+        entry.runtime_data.authenticated = True
+        LOGGER.debug("Token refreshed successfully")
 
     cancel_refresh = async_track_time_interval(
         hass,

--- a/custom_components/engie_be/config_flow.py
+++ b/custom_components/engie_be/config_flow.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 from homeassistant import config_entries
@@ -38,6 +38,9 @@ from .const import (
     MIN_UPDATE_INTERVAL_MINUTES,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
 
 class EngieBeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle the config flow for ENGIE Belgium."""
@@ -50,6 +53,7 @@ class EngieBeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._user_input: dict[str, Any] = {}
         self._auth_flow_state: AuthFlowState | None = None
         self._client: EngieBeApiClient | None = None
+        self._reauth_mfa_method: str = MFA_METHOD_SMS
 
     @staticmethod
     def async_get_options_flow(
@@ -217,11 +221,7 @@ class EngieBeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None and self._auth_flow_state is not None:
             try:
-                (
-                    access_token,
-                    refresh_token,
-                ) = await self._client.async_complete_authentication(
-                    flow_state=self._auth_flow_state,
+                access_token, refresh_token = await self._complete_mfa(
                     mfa_code=user_input["code"],
                     mfa_method=mfa_method,
                 )
@@ -238,8 +238,6 @@ class EngieBeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 LOGGER.exception(exception)
                 errors["base"] = "unknown"
             else:
-                self._auth_flow_state = None
-
                 if self._user_input.get(CONF_DEBUG_LOGGING, False):
                     LOGGER.debug("Debug logging disabled after setup completed")
                     LOGGER.setLevel(logging.WARNING)
@@ -266,6 +264,153 @@ class EngieBeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id=step_id,
+            data_schema=vol.Schema(
+                {
+                    vol.Required("code"): selector.TextSelector(
+                        selector.TextSelectorConfig(
+                            type=selector.TextSelectorType.TEXT,
+                        ),
+                    ),
+                },
+            ),
+            errors=errors,
+        )
+
+    async def _complete_mfa(
+        self,
+        *,
+        mfa_code: str,
+        mfa_method: str,
+    ) -> tuple[str, str]:
+        """
+        Submit an MFA code and return the resulting (access, refresh) tokens.
+
+        Shared between the initial-setup flow and the reauth flow. The caller is
+        responsible for catching API exceptions and surfacing them as form errors.
+        """
+        if self._client is None or self._auth_flow_state is None:
+            msg = "MFA completion called without an active auth flow"
+            raise EngieBeApiClientError(msg)
+
+        try:
+            return await self._client.async_complete_authentication(
+                flow_state=self._auth_flow_state,
+                mfa_code=mfa_code,
+                mfa_method=mfa_method,
+            )
+        finally:
+            self._auth_flow_state = None
+
+    # ------------------------------------------------------------------
+    # Reauth flow
+    # ------------------------------------------------------------------
+
+    async def async_step_reauth(
+        self,
+        entry_data: Mapping[str, Any],  # noqa: ARG002
+    ) -> config_entries.ConfigFlowResult:
+        """Begin the reauth flow when stored credentials/tokens stop working."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> config_entries.ConfigFlowResult:
+        """Restart authentication using stored credentials, prompt for MFA method."""
+        errors: dict[str, str] = {}
+        entry = self._get_reauth_entry()
+
+        if user_input is not None:
+            mfa_method = user_input.get(CONF_MFA_METHOD, MFA_METHOD_SMS)
+            self._reauth_mfa_method = mfa_method
+
+            try:
+                self._client = EngieBeApiClient(
+                    session=async_get_clientsession(self.hass),
+                    client_id=entry.data.get(CONF_CLIENT_ID, DEFAULT_CLIENT_ID),
+                )
+                self._auth_flow_state = await self._client.async_start_authentication(
+                    username=entry.data[CONF_USERNAME],
+                    password=entry.data[CONF_PASSWORD],
+                    mfa_method=mfa_method,
+                )
+            except EngieBeApiClientAuthenticationError as exception:
+                LOGGER.warning(exception)
+                errors["base"] = "auth"
+            except EngieBeApiClientCommunicationError as exception:
+                LOGGER.error(exception)
+                errors["base"] = "connection"
+            except EngieBeApiClientError as exception:
+                LOGGER.exception(exception)
+                errors["base"] = "unknown"
+            else:
+                return await self.async_step_reauth_mfa()
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            description_placeholders={"username": entry.data.get(CONF_USERNAME, "")},
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_MFA_METHOD,
+                        default=self._reauth_mfa_method,
+                    ): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=[
+                                selector.SelectOptionDict(
+                                    value=MFA_METHOD_SMS,
+                                    label="SMS",
+                                ),
+                                selector.SelectOptionDict(
+                                    value=MFA_METHOD_EMAIL,
+                                    label="Email",
+                                ),
+                            ],
+                            mode=selector.SelectSelectorMode.DROPDOWN,
+                        ),
+                    ),
+                },
+            ),
+            errors=errors,
+        )
+
+    async def async_step_reauth_mfa(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> config_entries.ConfigFlowResult:
+        """Collect the MFA code during reauth and persist refreshed tokens."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None and self._auth_flow_state is not None:
+            try:
+                access_token, refresh_token = await self._complete_mfa(
+                    mfa_code=user_input["code"],
+                    mfa_method=self._reauth_mfa_method,
+                )
+            except EngieBeApiClientMfaError as exception:
+                LOGGER.warning(exception)
+                errors["base"] = "invalid_mfa_code"
+            except EngieBeApiClientAuthenticationError as exception:
+                LOGGER.warning(exception)
+                errors["base"] = "auth"
+            except EngieBeApiClientCommunicationError as exception:
+                LOGGER.error(exception)
+                errors["base"] = "connection"
+            except EngieBeApiClientError as exception:
+                LOGGER.exception(exception)
+                errors["base"] = "unknown"
+            else:
+                return self.async_update_reload_and_abort(
+                    self._get_reauth_entry(),
+                    data_updates={
+                        CONF_ACCESS_TOKEN: access_token,
+                        CONF_REFRESH_TOKEN: refresh_token,
+                    },
+                    reason="reauth_successful",
+                )
+
+        return self.async_show_form(
+            step_id="reauth_mfa",
             data_schema=vol.Schema(
                 {
                     vol.Required("code"): selector.TextSelector(

--- a/custom_components/engie_be/strings.json
+++ b/custom_components/engie_be/strings.json
@@ -29,6 +29,23 @@
                 "data": {
                     "code": "Verification code"
                 }
+            },
+            "reauth_confirm": {
+                "title": "Reauthenticate ENGIE Belgium",
+                "description": "Your stored ENGIE access has expired for {username}. Choose how you want to receive a new verification code to re-authenticate.",
+                "data": {
+                    "mfa_method": "Two-factor authentication method"
+                },
+                "data_description": {
+                    "mfa_method": "Choose how you want to receive your verification code."
+                }
+            },
+            "reauth_mfa": {
+                "title": "Enter verification code",
+                "description": "Enter the 6-digit verification code that was just sent to you to finish re-authenticating.",
+                "data": {
+                    "code": "Verification code"
+                }
             }
         },
         "error": {
@@ -38,7 +55,8 @@
             "invalid_mfa_code": "Invalid verification code. Please try again."
         },
         "abort": {
-            "already_configured": "This account is already configured."
+            "already_configured": "This account is already configured.",
+            "reauth_successful": "Re-authentication was successful."
         }
     },
     "options": {

--- a/custom_components/engie_be/translations/en.json
+++ b/custom_components/engie_be/translations/en.json
@@ -29,6 +29,23 @@
                 "data": {
                     "code": "Verification code"
                 }
+            },
+            "reauth_confirm": {
+                "title": "Reauthenticate ENGIE Belgium",
+                "description": "Your stored ENGIE access has expired for {username}. Choose how you want to receive a new verification code to re-authenticate.",
+                "data": {
+                    "mfa_method": "Two-factor authentication method"
+                },
+                "data_description": {
+                    "mfa_method": "Choose how you want to receive your verification code."
+                }
+            },
+            "reauth_mfa": {
+                "title": "Enter verification code",
+                "description": "Enter the 6-digit verification code that was just sent to you to finish re-authenticating.",
+                "data": {
+                    "code": "Verification code"
+                }
             }
         },
         "error": {
@@ -38,7 +55,8 @@
             "invalid_mfa_code": "Invalid verification code. Please try again."
         },
         "abort": {
-            "already_configured": "This account is already configured."
+            "already_configured": "This account is already configured.",
+            "reauth_successful": "Re-authentication was successful."
         }
     },
     "options": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,242 @@
+"""Smoke tests for the ENGIE Belgium config flow."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.engie_be.api import (
+    AuthFlowState,
+    EngieBeApiClientAuthenticationError,
+    EngieBeApiClientMfaError,
+)
+from custom_components.engie_be.const import (
+    CONF_ACCESS_TOKEN,
+    CONF_CLIENT_ID,
+    CONF_CUSTOMER_NUMBER,
+    CONF_MFA_METHOD,
+    CONF_REFRESH_TOKEN,
+    DEFAULT_CLIENT_ID,
+    DOMAIN,
+    MFA_METHOD_SMS,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_USER_INPUT = {
+    CONF_USERNAME: "user@example.com",
+    CONF_PASSWORD: "hunter2",
+    CONF_CUSTOMER_NUMBER: "123456789",
+    CONF_CLIENT_ID: DEFAULT_CLIENT_ID,
+    CONF_MFA_METHOD: MFA_METHOD_SMS,
+}
+
+_TOKENS = ("new-access-token", "new-refresh-token")
+
+
+def _fake_flow_state() -> AuthFlowState:
+    """Return a placeholder AuthFlowState for mocking."""
+    return AuthFlowState(
+        session=None,  # type: ignore[arg-type]
+        authorize_state="state",
+        login_state="login",
+        mfa_challenge_state="mfa",
+        code_verifier="verifier",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Initial setup flow
+# ---------------------------------------------------------------------------
+
+
+async def test_user_flow_happy_path_sms(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """A successful SMS-based setup creates a config entry with tokens."""
+    with (
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_start_authentication",
+            AsyncMock(return_value=_fake_flow_state()),
+        ),
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_complete_authentication",
+            AsyncMock(return_value=_TOKENS),
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "user"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _USER_INPUT
+        )
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "mfa_sms"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"code": "123456"}
+        )
+
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["title"] == _USER_INPUT[CONF_USERNAME]
+    assert result["data"][CONF_ACCESS_TOKEN] == _TOKENS[0]
+    assert result["data"][CONF_REFRESH_TOKEN] == _TOKENS[1]
+    assert result["data"][CONF_CUSTOMER_NUMBER] == "00123456789"
+
+
+async def test_user_flow_invalid_credentials(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """Bad credentials surface as a form-level auth error."""
+    with patch(
+        "custom_components.engie_be.config_flow.EngieBeApiClient.async_start_authentication",
+        AsyncMock(side_effect=EngieBeApiClientAuthenticationError("bad creds")),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _USER_INPUT
+        )
+
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "auth"}
+
+
+async def test_user_flow_invalid_mfa_code(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """A bad MFA code surfaces as invalid_mfa_code and stays on the MFA step."""
+    with (
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_start_authentication",
+            AsyncMock(return_value=_fake_flow_state()),
+        ),
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_complete_authentication",
+            AsyncMock(side_effect=EngieBeApiClientMfaError("bad code")),
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _USER_INPUT
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"code": "000000"}
+        )
+
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "mfa_sms"
+    assert result["errors"] == {"base": "invalid_mfa_code"}
+
+
+async def test_user_flow_duplicate_aborts(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """Configuring the same username twice aborts with already_configured."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="user_example_com",
+        data={CONF_USERNAME: _USER_INPUT[CONF_USERNAME]},
+        version=2,
+    ).add_to_hass(hass)
+
+    with (
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_start_authentication",
+            AsyncMock(return_value=_fake_flow_state()),
+        ),
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_complete_authentication",
+            AsyncMock(return_value=_TOKENS),
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _USER_INPUT
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"code": "123456"}
+        )
+
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+# ---------------------------------------------------------------------------
+# Reauth flow
+# ---------------------------------------------------------------------------
+
+
+async def test_reauth_flow_updates_tokens(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """Reauth re-uses stored creds, prompts for MFA, and updates tokens in place."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="user_example_com",
+        data={
+            CONF_USERNAME: _USER_INPUT[CONF_USERNAME],
+            CONF_PASSWORD: _USER_INPUT[CONF_PASSWORD],
+            CONF_CUSTOMER_NUMBER: "00123456789",
+            CONF_CLIENT_ID: DEFAULT_CLIENT_ID,
+            CONF_ACCESS_TOKEN: "old-access",
+            CONF_REFRESH_TOKEN: "old-refresh",
+        },
+        version=2,
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_start_authentication",
+            AsyncMock(return_value=_fake_flow_state()),
+        ),
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_complete_authentication",
+            AsyncMock(return_value=_TOKENS),
+        ),
+    ):
+        result = await entry.start_reauth_flow(hass)
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "reauth_confirm"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_MFA_METHOD: MFA_METHOD_SMS}
+        )
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "reauth_mfa"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"code": "123456"}
+        )
+
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert entry.data[CONF_ACCESS_TOKEN] == _TOKENS[0]
+    assert entry.data[CONF_REFRESH_TOKEN] == _TOKENS[1]
+    # Stored credentials must remain untouched
+    assert entry.data[CONF_USERNAME] == _USER_INPUT[CONF_USERNAME]
+    assert entry.data[CONF_PASSWORD] == _USER_INPUT[CONF_PASSWORD]


### PR DESCRIPTION
## Summary
- Triggers reauth on refresh-token failure via `ConfigEntryAuthFailed` and `entry.async_start_reauth(hass)`
- Reuses stored username/password; prompts only for MFA method (SMS/email) and one-time code
- Uses modern HA 2024+ pattern: `self._get_reauth_entry()` + `async_update_reload_and_abort(...)`

## Test Plan
- 5 new tests in `tests/test_config_flow.py`:
  - happy-path user flow (SMS)
  - invalid credentials error
  - invalid MFA code error
  - duplicate-customer-number abort
  - reauth flow updates stored tokens
- Existing 26 sensor tests continue to pass
- ruff: clean