### PR TITLE
chore(audit): translatable exceptions, http status constants, README sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,62 @@ After setup, you can configure the price update interval:
 2. Find the **ENGIE Belgium** integration and click **Configure**
 3. Set the **Update interval** (5--1440 minutes, default: 60 minutes)
 
+## Re-authentication
+
+ENGIE rotates refresh tokens regularly, and the upstream auth server can
+revoke a session at any time (for example, when the same account logs in
+elsewhere). When that happens, Home Assistant will surface a **"Repair"**
+notification asking you to re-authenticate.
+
+To complete re-authentication:
+
+1. Open **Settings** > **Devices & Services** and click the
+   **Reconfigure** prompt on the ENGIE Belgium card (or click the
+   notification).
+2. Choose how you want to receive a verification code (SMS or email).
+3. Enter the 6-digit code that ENGIE sends you.
+
+Your stored email, password, and customer number are reused; only fresh
+access and refresh tokens are written back to the config entry. No
+sensors are removed and no history is lost.
+
+## Troubleshooting
+
+If the integration is misbehaving, work through these steps before
+filing an issue:
+
+1. **Enable debug logging.** During the initial setup flow you can tick
+   **Enable debug logging** to capture verbose API traffic in the Home
+   Assistant log. To enable it after setup, add the following to
+   `configuration.yaml` and restart Home Assistant:
+
+   ```yaml
+   logger:
+     logs:
+       custom_components.engie_be: debug
+   ```
+
+2. **Download diagnostics.** Open the integration in **Settings** >
+   **Devices & Services**, click the three-dot menu on the ENGIE Belgium
+   entry, and choose **Download diagnostics**. The resulting JSON
+   redacts your password, tokens, and EAN identifiers, and is safe to
+   attach to a GitHub issue.
+
+3. **Common errors.**
+   - *Authentication with ENGIE Belgium failed*: your stored tokens
+     were rejected. Follow the [Re-authentication](#re-authentication)
+     steps above.
+   - *Cannot connect to the ENGIE Belgium API*: the upstream API is
+     unreachable or returned an HTTP error. The coordinator will retry
+     on its next interval; check
+     [status.engie.be](https://status.engie.be) if the issue persists.
+   - *Invalid verification code*: re-trigger the MFA step and enter the
+     latest code.
+
+4. **File an issue.** If the problem persists, open one at
+   [github.com/DaanVervacke/hass-engie-be/issues](https://github.com/DaanVervacke/hass-engie-be/issues)
+   and include the diagnostics JSON plus the relevant log lines.
+
 ## How it works
 
 - **Authentication**: Uses OAuth2 with PKCE (public client, no secret) through

--- a/custom_components/engie_be/api.py
+++ b/custom_components/engie_be/api.py
@@ -9,7 +9,8 @@ import re
 import socket
 from base64 import urlsafe_b64encode
 from dataclasses import dataclass
-from typing import Any
+from http import HTTPStatus
+from typing import Any, NoReturn
 
 import aiohttp
 
@@ -45,6 +46,12 @@ class EngieBeApiClientAuthenticationError(EngieBeApiClientError):
 
 class EngieBeApiClientMfaError(EngieBeApiClientError):
     """Exception for MFA-related errors (invalid code)."""
+
+
+def _raise_auth_error(status: int) -> NoReturn:
+    """Raise an authentication error tagged with the offending HTTP status."""
+    msg = f"Authentication failed ({status})"
+    raise EngieBeApiClientAuthenticationError(msg)
 
 
 # ---------------------------------------------------------------------------
@@ -738,14 +745,16 @@ class EngieBeApiClient:
                     allow_redirects=allow_redirects,
                 )
                 if raise_on_error:
-                    if response.status in (401, 403):
-                        msg = f"Authentication failed ({response.status})"
-                        raise EngieBeApiClientAuthenticationError(msg)  # noqa: TRY301
+                    if response.status in (
+                        HTTPStatus.UNAUTHORIZED,
+                        HTTPStatus.FORBIDDEN,
+                    ):
+                        _raise_auth_error(response.status)
 
                     # For auth-flow HTML pages, non-200/302 is likely an
                     # error but we don't raise_for_status on 3xx since we
                     # handle redirects manually.
-                    if response.status >= 400:  # noqa: PLR2004
+                    if response.status >= HTTPStatus.BAD_REQUEST:
                         response.raise_for_status()
 
                 if json_response:

--- a/custom_components/engie_be/coordinator.py
+++ b/custom_components/engie_be/coordinator.py
@@ -20,6 +20,7 @@ from .const import (
     CONF_CUSTOMER_NUMBER,
     CONF_UPDATE_INTERVAL,
     DEFAULT_UPDATE_INTERVAL_MINUTES,
+    DOMAIN,
     LOGGER,
 )
 
@@ -61,9 +62,15 @@ class EngieBeDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         try:
             data = await client.async_get_prices(customer_number)
         except EngieBeApiClientAuthenticationError as exception:
-            raise ConfigEntryAuthFailed(exception) from exception
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="auth_failed",
+            ) from exception
         except EngieBeApiClientError as exception:
-            raise UpdateFailed(exception) from exception
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="cannot_connect",
+            ) from exception
 
         self.last_successful_fetch = dt_util.utcnow()
         return data

--- a/custom_components/engie_be/strings.json
+++ b/custom_components/engie_be/strings.json
@@ -12,6 +12,8 @@
                     "debug_logging": "Enable debug logging"
                 },
                 "data_description": {
+                    "username": "Your ENGIE Belgium account email address.",
+                    "password": "Your ENGIE Belgium account password.",
                     "customer_number": "Enter your ENGIE Belgium customer number as shown in the ENGIE Smart app. The 00 prefix is added automatically.",
                     "client_id": "OAuth client ID. Only change this if you know what you are doing.",
                     "mfa_method": "Choose how you want to receive your verification code.",
@@ -22,12 +24,18 @@
                 "description": "Enter the 6-digit verification code that was sent to your phone via SMS.",
                 "data": {
                     "code": "Verification code"
+                },
+                "data_description": {
+                    "code": "The 6-digit code that ENGIE just sent you."
                 }
             },
             "mfa_email": {
                 "description": "Enter the 6-digit verification code that was sent to your email address.",
                 "data": {
                     "code": "Verification code"
+                },
+                "data_description": {
+                    "code": "The 6-digit code that ENGIE just sent you."
                 }
             },
             "reauth_confirm": {
@@ -45,6 +53,9 @@
                 "description": "Enter the 6-digit verification code that was just sent to you to finish re-authenticating.",
                 "data": {
                     "code": "Verification code"
+                },
+                "data_description": {
+                    "code": "The 6-digit code that ENGIE just sent you."
                 }
             }
         },
@@ -57,6 +68,17 @@
         "abort": {
             "already_configured": "This account is already configured.",
             "reauth_successful": "Re-authentication was successful."
+        }
+    },
+    "exceptions": {
+        "cannot_connect": {
+            "message": "Cannot connect to the ENGIE Belgium API."
+        },
+        "auth_failed": {
+            "message": "Authentication with ENGIE Belgium failed; please re-authenticate."
+        },
+        "unknown_error": {
+            "message": "An unknown error occurred while talking to the ENGIE Belgium API."
         }
     },
     "options": {

--- a/custom_components/engie_be/translations/en.json
+++ b/custom_components/engie_be/translations/en.json
@@ -12,6 +12,8 @@
                     "debug_logging": "Enable debug logging"
                 },
                 "data_description": {
+                    "username": "Your ENGIE Belgium account email address.",
+                    "password": "Your ENGIE Belgium account password.",
                     "customer_number": "Enter your ENGIE Belgium customer number as shown in the ENGIE Smart app. The 00 prefix is added automatically.",
                     "client_id": "OAuth client ID. Only change this if you know what you are doing.",
                     "mfa_method": "Choose how you want to receive your verification code.",
@@ -22,12 +24,18 @@
                 "description": "Enter the 6-digit verification code that was sent to your phone via SMS.",
                 "data": {
                     "code": "Verification code"
+                },
+                "data_description": {
+                    "code": "The 6-digit code that ENGIE just sent you."
                 }
             },
             "mfa_email": {
                 "description": "Enter the 6-digit verification code that was sent to your email address.",
                 "data": {
                     "code": "Verification code"
+                },
+                "data_description": {
+                    "code": "The 6-digit code that ENGIE just sent you."
                 }
             },
             "reauth_confirm": {
@@ -45,6 +53,9 @@
                 "description": "Enter the 6-digit verification code that was just sent to you to finish re-authenticating.",
                 "data": {
                     "code": "Verification code"
+                },
+                "data_description": {
+                    "code": "The 6-digit code that ENGIE just sent you."
                 }
             }
         },
@@ -57,6 +68,17 @@
         "abort": {
             "already_configured": "This account is already configured.",
             "reauth_successful": "Re-authentication was successful."
+        }
+    },
+    "exceptions": {
+        "cannot_connect": {
+            "message": "Cannot connect to the ENGIE Belgium API."
+        },
+        "auth_failed": {
+            "message": "Authentication with ENGIE Belgium failed; please re-authenticate."
+        },
+        "unknown_error": {
+            "message": "An unknown error occurred while talking to the ENGIE Belgium API."
         }
     },
     "options": {


### PR DESCRIPTION
## Summary

Audit-cleanup PR bundling three small, independent improvements identified during the Bronze-tier prep audit. No behaviour changes; surface area is mostly user-visible copy and a tiny api.py refactor.

### B — Translatable exceptions and missing data_description hints

- Add a top-level `exceptions` block to `strings.json` (mirrored to `translations/en.json`) with three keys: `cannot_connect`, `auth_failed`, `unknown_error`.
- Update `coordinator.py` so `ConfigEntryAuthFailed` and `UpdateFailed` carry `translation_domain=DOMAIN` + `translation_key=...`, letting HA localize the message in the UI rather than dumping the raw API exception text.
- Fill in the gaps in `data_description`: `username` and `password` on the user step, and `code` on every MFA step (`mfa_sms`, `mfa_email`, `reauth_mfa`). Existing entries are unchanged.

### C — Drop two ruff suppressions in `api.py:_api_wrapper`

- Extract the inline `raise EngieBeApiClientAuthenticationError(...)` into a module-level `_raise_auth_error` helper so `# noqa: TRY301` is no longer needed.
- Replace the magic numbers `401`, `403`, `400` with `HTTPStatus.UNAUTHORIZED`, `HTTPStatus.FORBIDDEN`, `HTTPStatus.BAD_REQUEST` so `# noqa: PLR2004` is no longer needed.
- Behaviour is identical; covered indirectly by config-flow + coordinator tests.

### D — Document re-authentication and troubleshooting in README

- New `## Re-authentication` section walks the user through the Repair-notification flow that ships with the recent reauth work.
- New `## Troubleshooting` section covers debug logging, downloading diagnostics, common error messages, and where to file issues.

## Test plan

- `uvx ruff check custom_components/` passes (both removed `# noqa` lines no longer needed).
- `uvx ruff format --check custom_components/` clean.
- JSON files parse.
- Existing `tests/test_coordinator.py` already asserts on exception type and `__cause__` chain only — unaffected by translation_key wiring.
- CI will run the full pytest + Hassfest + HACS matrix on push.

## Risk

Low. The only runtime change is the translation-key wiring on two raises in `coordinator.py`; the test suite covers both code paths and only inspects exception type + cause, so it stays green. Everything else is copy or refactor.