### PR TITLE
fix: harden logging and remove redundant debug toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,11 @@ sensors are removed and no history is lost.
 If the integration is misbehaving, work through these steps before
 filing an issue:
 
-1. **Enable debug logging.** During the initial setup flow you can tick
-   **Enable debug logging** to capture verbose API traffic in the Home
-   Assistant log. To enable it after setup, add the following to
+1. **Enable debug logging.** Open **Settings** > **Devices & Services**,
+   click the three-dot menu on the ENGIE Belgium entry, and select
+   **Enable debug logging**. Reproduce the issue, then choose **Disable
+   debug logging** from the same menu — Home Assistant will offer to
+   download the captured log. Alternatively, add the following to
    `configuration.yaml` and restart Home Assistant:
 
    ```yaml
@@ -189,14 +191,33 @@ filing an issue:
      steps above.
    - *Cannot connect to the ENGIE Belgium API*: the upstream API is
      unreachable or returned an HTTP error. The coordinator will retry
-     on its next interval; check
-     [status.engie.be](https://status.engie.be) if the issue persists.
+     on its next interval.
    - *Invalid verification code*: re-trigger the MFA step and enter the
      latest code.
 
 4. **File an issue.** If the problem persists, open one at
    [github.com/DaanVervacke/hass-engie-be/issues](https://github.com/DaanVervacke/hass-engie-be/issues)
    and include the diagnostics JSON plus the relevant log lines.
+
+## Credential storage
+
+This integration stores your ENGIE email, password, customer number,
+client ID, and the latest OAuth access and refresh tokens in the
+config entry (`.storage/core.config_entries`), which Home Assistant
+keeps as plain JSON on disk. This is the standard Home Assistant
+pattern for integrations that need persisted credentials.
+
+The password is kept (rather than discarded after setup) because the
+re-authentication flow re-runs the upstream OAuth `Resource Owner
+Password Credentials` exchange to begin a new MFA challenge — without
+the password, every token revocation would require fully removing and
+re-adding the integration.
+
+If you do not want the password on disk, treat this integration the
+same as any other credential-storing HA integration: protect the host,
+restrict filesystem access, and consider full-disk encryption. The
+**Download diagnostics** payload redacts all of these fields and is
+safe to share.
 
 ## How it works
 

--- a/custom_components/engie_be/__init__.py
+++ b/custom_components/engie_be/__init__.py
@@ -26,6 +26,7 @@ from .const import (
 )
 from .coordinator import EngieBeDataUpdateCoordinator
 from .data import EngieBeData
+from .diagnostics import _hash_ean
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -142,10 +143,11 @@ async def async_setup_entry(
             division: str = sp_data.get("division", "")
             if division:
                 service_points[ean] = division
-                LOGGER.debug("Service-point %s: division=%s", ean, division)
+                LOGGER.debug("Service-point %s: division=%s", _hash_ean(ean), division)
         except EngieBeApiClientError:
             LOGGER.warning(
-                "Failed to fetch service-point for EAN %s; using fallback", ean
+                "Failed to fetch service-point for EAN %s; using fallback",
+                _hash_ean(ean),
             )
     entry.runtime_data.service_points = service_points
 

--- a/custom_components/engie_be/api.py
+++ b/custom_components/engie_be/api.py
@@ -769,11 +769,16 @@ class EngieBeApiClient:
         except EngieBeApiClientError:
             raise
         except TimeoutError as exception:
-            msg = f"Timeout communicating with Engie API - {exception}"
+            msg = (
+                f"Timeout communicating with Engie API ({exception.__class__.__name__})"
+            )
             raise EngieBeApiClientCommunicationError(msg) from exception
         except (aiohttp.ClientError, socket.gaierror) as exception:
-            msg = f"Error communicating with Engie API - {exception}"
+            msg = f"Error communicating with Engie API ({exception.__class__.__name__})"
             raise EngieBeApiClientCommunicationError(msg) from exception
         except Exception as exception:
-            msg = f"Unexpected error communicating with Engie API - {exception}"
+            msg = (
+                "Unexpected error communicating with Engie API "
+                f"({exception.__class__.__name__})"
+            )
             raise EngieBeApiClientError(msg) from exception

--- a/custom_components/engie_be/config_flow.py
+++ b/custom_components/engie_be/config_flow.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
@@ -24,7 +23,6 @@ from .const import (
     CONF_ACCESS_TOKEN,
     CONF_CLIENT_ID,
     CONF_CUSTOMER_NUMBER,
-    CONF_DEBUG_LOGGING,
     CONF_MFA_METHOD,
     CONF_REFRESH_TOKEN,
     CONF_UPDATE_INTERVAL,
@@ -75,10 +73,6 @@ class EngieBeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             self._user_input = user_input
-
-            if user_input.get(CONF_DEBUG_LOGGING, False):
-                LOGGER.setLevel(logging.DEBUG)
-                LOGGER.debug("Debug logging enabled via setup flow")
 
             try:
                 self._client = EngieBeApiClient(
@@ -166,10 +160,6 @@ class EngieBeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                             mode=selector.SelectSelectorMode.DROPDOWN,
                         ),
                     ),
-                    vol.Optional(
-                        CONF_DEBUG_LOGGING,
-                        default=False,
-                    ): selector.BooleanSelector(),
                 },
             ),
             errors=errors,
@@ -238,10 +228,6 @@ class EngieBeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 LOGGER.exception(exception)
                 errors["base"] = "unknown"
             else:
-                if self._user_input.get(CONF_DEBUG_LOGGING, False):
-                    LOGGER.debug("Debug logging disabled after setup completed")
-                    LOGGER.setLevel(logging.WARNING)
-
                 raw_number = self._user_input[CONF_CUSTOMER_NUMBER]
                 customer_number = f"00{raw_number.replace(' ', '')}"
 

--- a/custom_components/engie_be/const.py
+++ b/custom_components/engie_be/const.py
@@ -26,7 +26,6 @@ CONF_MFA_METHOD = "mfa_method"
 CONF_CLIENT_ID = "client_id"
 CONF_ACCESS_TOKEN = "access_token"  # noqa: S105
 CONF_REFRESH_TOKEN = "refresh_token"  # noqa: S105
-CONF_DEBUG_LOGGING = "debug_logging"
 
 # MFA method options
 MFA_METHOD_SMS = "sms"

--- a/custom_components/engie_be/strings.json
+++ b/custom_components/engie_be/strings.json
@@ -8,16 +8,14 @@
                     "password": "Password",
                     "customer_number": "Customer number",
                     "client_id": "Client ID",
-                    "mfa_method": "Two-factor authentication method",
-                    "debug_logging": "Enable debug logging"
+                    "mfa_method": "Two-factor authentication method"
                 },
                 "data_description": {
                     "username": "Your ENGIE Belgium account email address.",
                     "password": "Your ENGIE Belgium account password.",
                     "customer_number": "Enter your ENGIE Belgium customer number as shown in the ENGIE Smart app. The 00 prefix is added automatically.",
                     "client_id": "OAuth client ID. Only change this if you know what you are doing.",
-                    "mfa_method": "Choose how you want to receive your verification code.",
-                    "debug_logging": "Temporarily enable verbose debug logging to help troubleshoot setup issues."
+                    "mfa_method": "Choose how you want to receive your verification code."
                 }
             },
             "mfa_sms": {

--- a/custom_components/engie_be/translations/en.json
+++ b/custom_components/engie_be/translations/en.json
@@ -8,16 +8,14 @@
                     "password": "Password",
                     "customer_number": "Customer number",
                     "client_id": "Client ID",
-                    "mfa_method": "Two-factor authentication method",
-                    "debug_logging": "Enable debug logging"
+                    "mfa_method": "Two-factor authentication method"
                 },
                 "data_description": {
                     "username": "Your ENGIE Belgium account email address.",
                     "password": "Your ENGIE Belgium account password.",
                     "customer_number": "Enter your ENGIE Belgium customer number as shown in the ENGIE Smart app. The 00 prefix is added automatically.",
                     "client_id": "OAuth client ID. Only change this if you know what you are doing.",
-                    "mfa_method": "Choose how you want to receive your verification code.",
-                    "debug_logging": "Temporarily enable verbose debug logging to help troubleshoot setup issues."
+                    "mfa_method": "Choose how you want to receive your verification code."
                 }
             },
             "mfa_sms": {


### PR DESCRIPTION
## Summary

Addresses three findings from the security audit (`.opencode/audit-security.md`).

### 1. Hash EAN before logging (`__init__.py`)

The WARNING-level log emitted when a config entry or coordinator data was missing previously included the full EAN. EANs are PII (uniquely identify a metering point and, by extension, an address). Both the DEBUG and WARNING log lines now hash the EAN with `_hash_ean()`, matching the pattern already established in `diagnostics.py`.

### 2. Remove `CONF_DEBUG_LOGGING` config flow toggle

This toggle duplicated functionality Home Assistant provides natively — per-integration debug logging via **Settings → Devices & Services → ⋮ → Enable debug logging**. Removing it eliminates a source of confusion and one fewer code path that mutates global logger state at runtime.

Removed from:
- `const.py` (`CONF_DEBUG_LOGGING` constant)
- `config_flow.py` (form field, `import logging`, `LOGGER.setLevel(DEBUG)` on submit, `LOGGER.setLevel(WARNING)` on abort)
- `strings.json` and `translations/en.json` (form labels + descriptions)

### 3. Sanitize exception messages in `api._api_wrapper`

Exception messages previously interpolated the full exception object via `f\"...: {exception}\"`. For `aiohttp` errors, the string representation can contain the request URL — which during the OAuth/PKCE flow includes `state` and `code` query parameters. Sanitized messages now log only `exception.__class__.__name__`; the `raise ... from exception` chain still preserves the original cause for debugging.

### README updates

- Rewrote the Troubleshooting **\"Enable debug logging\"** section to point at HA's standard per-integration toggle (with `configuration.yaml` fallback).
- Removed the reference to `status.engie.be` (does not exist).
- Added a new **Credential storage** section explaining why the password must be persisted in plaintext inside `.storage` (the reauth flow re-runs ROPC and needs the credentials).

## Lint / format

- `ruff check` clean across `custom_components/engie_be/` and `tests/`
- `ruff format --check` clean

## Test impact

No existing test references the removed surfaces:
- `test_config_flow.py` does not reference `debug_logging` / `CONF_DEBUG_LOGGING`.
- No test asserts on the exact text of `_api_wrapper` exception messages (they assert exception type + `__cause__`).
- `_hash_ean` is already imported privately in `test_diagnostics.py`, establishing the cross-module import pattern.