### PR TITLE
chore: prepare for Bronze quality scale declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,21 @@ Your stored email, password, and customer number are reused; only fresh
 access and refresh tokens are written back to the config entry. No
 sensors are removed and no history is lost.
 
+## Removing the integration
+
+This integration follows the standard Home Assistant removal flow and does
+not leave any state behind on Home Assistant or on the ENGIE side.
+
+1. Go to **Settings** > **Devices & Services**.
+2. Find the **ENGIE Belgium** card and click the three-dot menu.
+3. Select **Delete**.
+
+Removing the entry deletes its sensors and the stored credentials and
+tokens (`.storage/core.config_entries` is updated by Home Assistant). No
+cleanup is required on your ENGIE account: the integration only reads
+data and never modifies anything upstream. The OAuth refresh token in
+the deleted entry is left to expire naturally on ENGIE's side.
+
 ## Troubleshooting
 
 If the integration is misbehaving, work through these steps before

--- a/custom_components/engie_be/quality_scale.yaml
+++ b/custom_components/engie_be/quality_scale.yaml
@@ -1,0 +1,26 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: Integration does not register any service actions.
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: Integration does not register any service actions.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  entity-event-setup:
+    status: exempt
+    comment: Entities are coordinator-driven; no library event subscriptions to manage.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
+import pytest
+import voluptuous as vol
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -12,6 +14,8 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.engie_be.api import (
     AuthFlowState,
     EngieBeApiClientAuthenticationError,
+    EngieBeApiClientCommunicationError,
+    EngieBeApiClientError,
     EngieBeApiClientMfaError,
 )
 from custom_components.engie_be.const import (
@@ -20,9 +24,13 @@ from custom_components.engie_be.const import (
     CONF_CUSTOMER_NUMBER,
     CONF_MFA_METHOD,
     CONF_REFRESH_TOKEN,
+    CONF_UPDATE_INTERVAL,
     DEFAULT_CLIENT_ID,
     DOMAIN,
+    MAX_UPDATE_INTERVAL_MINUTES,
+    MFA_METHOD_EMAIL,
     MFA_METHOD_SMS,
+    MIN_UPDATE_INTERVAL_MINUTES,
 )
 
 if TYPE_CHECKING:
@@ -240,3 +248,553 @@ async def test_reauth_flow_updates_tokens(
     # Stored credentials must remain untouched
     assert entry.data[CONF_USERNAME] == _USER_INPUT[CONF_USERNAME]
     assert entry.data[CONF_PASSWORD] == _USER_INPUT[CONF_PASSWORD]
+
+
+# ---------------------------------------------------------------------------
+# Initial setup flow: email MFA + non-auth error recovery
+# ---------------------------------------------------------------------------
+
+
+async def test_user_flow_happy_path_email(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """A successful email-based setup creates a config entry with tokens."""
+    user_input = {**_USER_INPUT, CONF_MFA_METHOD: MFA_METHOD_EMAIL}
+
+    with (
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_start_authentication",
+            AsyncMock(return_value=_fake_flow_state()),
+        ),
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_complete_authentication",
+            AsyncMock(return_value=_TOKENS),
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input
+        )
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "mfa_email"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"code": "654321"}
+        )
+
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_ACCESS_TOKEN] == _TOKENS[0]
+    assert result["data"][CONF_REFRESH_TOKEN] == _TOKENS[1]
+
+
+async def test_user_flow_connection_error_recovers(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """A transient connection error surfaces, then the user can retry and succeed."""
+    start_auth = AsyncMock(
+        side_effect=[
+            EngieBeApiClientCommunicationError("network down"),
+            _fake_flow_state(),
+        ]
+    )
+    with (
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_start_authentication",
+            start_auth,
+        ),
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_complete_authentication",
+            AsyncMock(return_value=_TOKENS),
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _USER_INPUT
+        )
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "user"
+        assert result["errors"] == {"base": "connection"}
+
+        # Retry: same input, this time the client succeeds.
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _USER_INPUT
+        )
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "mfa_sms"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"code": "123456"}
+        )
+
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert start_auth.await_count == 2
+
+
+async def test_user_flow_unknown_error_recovers(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """A generic API error surfaces as 'unknown' and is recoverable on retry."""
+    start_auth = AsyncMock(
+        side_effect=[
+            EngieBeApiClientError("boom"),
+            _fake_flow_state(),
+        ]
+    )
+    with (
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_start_authentication",
+            start_auth,
+        ),
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_complete_authentication",
+            AsyncMock(return_value=_TOKENS),
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _USER_INPUT
+        )
+        assert result["errors"] == {"base": "unknown"}
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _USER_INPUT
+        )
+        assert result["step_id"] == "mfa_sms"
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"code": "123456"}
+        )
+
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
+
+
+# ---------------------------------------------------------------------------
+# MFA step: non-MFA error recovery (auth / connection / unknown)
+# ---------------------------------------------------------------------------
+
+
+async def test_mfa_step_auth_error_recovers(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """An auth failure during MFA exchange surfaces and is recoverable."""
+    complete = AsyncMock(
+        side_effect=[
+            EngieBeApiClientAuthenticationError("expired"),
+        ]
+    )
+    with (
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_start_authentication",
+            AsyncMock(return_value=_fake_flow_state()),
+        ),
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_complete_authentication",
+            complete,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _USER_INPUT
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"code": "123456"}
+        )
+
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "mfa_sms"
+    assert result["errors"] == {"base": "auth"}
+
+
+async def test_mfa_step_connection_error_recovers(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """A connection failure during MFA exchange surfaces as 'connection'."""
+    with (
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_start_authentication",
+            AsyncMock(return_value=_fake_flow_state()),
+        ),
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_complete_authentication",
+            AsyncMock(side_effect=EngieBeApiClientCommunicationError("network down")),
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _USER_INPUT
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"code": "123456"}
+        )
+
+    assert result["step_id"] == "mfa_sms"
+    assert result["errors"] == {"base": "connection"}
+
+
+async def test_mfa_step_unknown_error_recovers(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """A generic API error during MFA exchange surfaces as 'unknown'."""
+    with (
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_start_authentication",
+            AsyncMock(return_value=_fake_flow_state()),
+        ),
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_complete_authentication",
+            AsyncMock(side_effect=EngieBeApiClientError("boom")),
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _USER_INPUT
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"code": "123456"}
+        )
+
+    assert result["step_id"] == "mfa_sms"
+    assert result["errors"] == {"base": "unknown"}
+
+
+# ---------------------------------------------------------------------------
+# Reauth flow: email + every error branch (start_authentication and MFA)
+# ---------------------------------------------------------------------------
+
+
+def _build_reauth_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Build a v2 entry suitable for reauth flow tests."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="user_example_com",
+        data={
+            CONF_USERNAME: _USER_INPUT[CONF_USERNAME],
+            CONF_PASSWORD: _USER_INPUT[CONF_PASSWORD],
+            CONF_CUSTOMER_NUMBER: "00123456789",
+            CONF_CLIENT_ID: DEFAULT_CLIENT_ID,
+            CONF_ACCESS_TOKEN: "old-access",
+            CONF_REFRESH_TOKEN: "old-refresh",
+        },
+        version=2,
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def test_reauth_flow_email_updates_tokens(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """Reauth via email follows the same shape as SMS and updates tokens."""
+    entry = _build_reauth_entry(hass)
+
+    with (
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_start_authentication",
+            AsyncMock(return_value=_fake_flow_state()),
+        ),
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_complete_authentication",
+            AsyncMock(return_value=_TOKENS),
+        ),
+    ):
+        result = await entry.start_reauth_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_MFA_METHOD: MFA_METHOD_EMAIL}
+        )
+        assert result["step_id"] == "reauth_mfa"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"code": "654321"}
+        )
+
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert entry.data[CONF_ACCESS_TOKEN] == _TOKENS[0]
+
+
+async def test_reauth_confirm_auth_error_recovers(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """Reauth confirm step: auth error surfaces, retry succeeds."""
+    entry = _build_reauth_entry(hass)
+    start_auth = AsyncMock(
+        side_effect=[
+            EngieBeApiClientAuthenticationError("creds rotated"),
+            _fake_flow_state(),
+        ]
+    )
+
+    with (
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_start_authentication",
+            start_auth,
+        ),
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_complete_authentication",
+            AsyncMock(return_value=_TOKENS),
+        ),
+    ):
+        result = await entry.start_reauth_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_MFA_METHOD: MFA_METHOD_SMS}
+        )
+        assert result["step_id"] == "reauth_confirm"
+        assert result["errors"] == {"base": "auth"}
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_MFA_METHOD: MFA_METHOD_SMS}
+        )
+        assert result["step_id"] == "reauth_mfa"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"code": "123456"}
+        )
+
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+
+
+async def test_reauth_confirm_connection_error(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """Reauth confirm step: connection error surfaces as 'connection'."""
+    entry = _build_reauth_entry(hass)
+
+    with patch(
+        "custom_components.engie_be.config_flow.EngieBeApiClient.async_start_authentication",
+        AsyncMock(side_effect=EngieBeApiClientCommunicationError("offline")),
+    ):
+        result = await entry.start_reauth_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_MFA_METHOD: MFA_METHOD_SMS}
+        )
+
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"] == {"base": "connection"}
+
+
+async def test_reauth_confirm_unknown_error(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """Reauth confirm step: generic API error surfaces as 'unknown'."""
+    entry = _build_reauth_entry(hass)
+
+    with patch(
+        "custom_components.engie_be.config_flow.EngieBeApiClient.async_start_authentication",
+        AsyncMock(side_effect=EngieBeApiClientError("boom")),
+    ):
+        result = await entry.start_reauth_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_MFA_METHOD: MFA_METHOD_SMS}
+        )
+
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"] == {"base": "unknown"}
+
+
+async def test_reauth_mfa_invalid_code_recovers(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """Reauth MFA step: invalid code surfaces as 'invalid_mfa_code'."""
+    entry = _build_reauth_entry(hass)
+
+    with (
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_start_authentication",
+            AsyncMock(return_value=_fake_flow_state()),
+        ),
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_complete_authentication",
+            AsyncMock(side_effect=EngieBeApiClientMfaError("nope")),
+        ),
+    ):
+        result = await entry.start_reauth_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_MFA_METHOD: MFA_METHOD_SMS}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"code": "000000"}
+        )
+
+    assert result["step_id"] == "reauth_mfa"
+    assert result["errors"] == {"base": "invalid_mfa_code"}
+
+
+async def test_reauth_mfa_auth_error(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """Reauth MFA step: auth error surfaces as 'auth'."""
+    entry = _build_reauth_entry(hass)
+
+    with (
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_start_authentication",
+            AsyncMock(return_value=_fake_flow_state()),
+        ),
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_complete_authentication",
+            AsyncMock(side_effect=EngieBeApiClientAuthenticationError("expired")),
+        ),
+    ):
+        result = await entry.start_reauth_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_MFA_METHOD: MFA_METHOD_SMS}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"code": "123456"}
+        )
+
+    assert result["step_id"] == "reauth_mfa"
+    assert result["errors"] == {"base": "auth"}
+
+
+async def test_reauth_mfa_connection_error(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """Reauth MFA step: connection error surfaces as 'connection'."""
+    entry = _build_reauth_entry(hass)
+
+    with (
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_start_authentication",
+            AsyncMock(return_value=_fake_flow_state()),
+        ),
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_complete_authentication",
+            AsyncMock(side_effect=EngieBeApiClientCommunicationError("offline")),
+        ),
+    ):
+        result = await entry.start_reauth_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_MFA_METHOD: MFA_METHOD_SMS}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"code": "123456"}
+        )
+
+    assert result["step_id"] == "reauth_mfa"
+    assert result["errors"] == {"base": "connection"}
+
+
+async def test_reauth_mfa_unknown_error(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """Reauth MFA step: generic API error surfaces as 'unknown'."""
+    entry = _build_reauth_entry(hass)
+
+    with (
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_start_authentication",
+            AsyncMock(return_value=_fake_flow_state()),
+        ),
+        patch(
+            "custom_components.engie_be.config_flow.EngieBeApiClient.async_complete_authentication",
+            AsyncMock(side_effect=EngieBeApiClientError("boom")),
+        ),
+    ):
+        result = await entry.start_reauth_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_MFA_METHOD: MFA_METHOD_SMS}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"code": "123456"}
+        )
+
+    assert result["step_id"] == "reauth_mfa"
+    assert result["errors"] == {"base": "unknown"}
+
+
+# ---------------------------------------------------------------------------
+# Options flow
+# ---------------------------------------------------------------------------
+
+
+async def test_options_flow_updates_interval(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """The options flow stores a new update interval on the entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="user_example_com",
+        data={
+            CONF_USERNAME: _USER_INPUT[CONF_USERNAME],
+            CONF_PASSWORD: _USER_INPUT[CONF_PASSWORD],
+            CONF_CUSTOMER_NUMBER: "00123456789",
+            CONF_CLIENT_ID: DEFAULT_CLIENT_ID,
+            CONF_ACCESS_TOKEN: "stored-access",
+            CONF_REFRESH_TOKEN: "stored-refresh",
+        },
+        options={CONF_UPDATE_INTERVAL: 60},
+        version=2,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {CONF_UPDATE_INTERVAL: 120}
+    )
+
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_UPDATE_INTERVAL] == 120
+
+
+async def test_options_flow_rejects_out_of_range(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """The options-flow schema enforces the configured min/max bounds."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="user_example_com",
+        data={
+            CONF_USERNAME: _USER_INPUT[CONF_USERNAME],
+            CONF_PASSWORD: _USER_INPUT[CONF_PASSWORD],
+            CONF_CUSTOMER_NUMBER: "00123456789",
+            CONF_CLIENT_ID: DEFAULT_CLIENT_ID,
+            CONF_ACCESS_TOKEN: "stored-access",
+            CONF_REFRESH_TOKEN: "stored-refresh",
+        },
+        options={CONF_UPDATE_INTERVAL: 60},
+        version=2,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    too_low = MIN_UPDATE_INTERVAL_MINUTES - 1
+    too_high = MAX_UPDATE_INTERVAL_MINUTES + 1
+
+    for bad in (too_low, too_high):
+        with pytest.raises(vol.Invalid):
+            await hass.config_entries.options.async_configure(
+                result["flow_id"], {CONF_UPDATE_INTERVAL: bad}
+            )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.engie_be import _persist_tokens
+from custom_components.engie_be import _persist_tokens, async_migrate_entry
 from custom_components.engie_be.api import (
     EngieBeApiClientAuthenticationError,
 )
@@ -17,6 +17,7 @@ from custom_components.engie_be.const import (
     CONF_CLIENT_ID,
     CONF_CUSTOMER_NUMBER,
     CONF_REFRESH_TOKEN,
+    CONF_UPDATE_INTERVAL,
     DEFAULT_CLIENT_ID,
     DOMAIN,
 )
@@ -199,3 +200,77 @@ def test_persist_tokens_writes_only_token_fields(
     assert entry.data[CONF_USERNAME] == "user@example.com"
     assert entry.data[CONF_PASSWORD] == "hunter2"
     assert entry.data[CONF_CUSTOMER_NUMBER] == "000000000000"
+
+
+# ---------------------------------------------------------------------------
+# Config-entry migration
+# ---------------------------------------------------------------------------
+
+
+async def test_migrate_v1_converts_hours_to_minutes(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """v1 stored update_interval in hours; migration must rewrite it to minutes."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=1,
+        title="user@example.com",
+        unique_id="user_example_com",
+        data={
+            CONF_USERNAME: "user@example.com",
+            CONF_PASSWORD: "hunter2",
+            CONF_CUSTOMER_NUMBER: "000000000000",
+            CONF_CLIENT_ID: DEFAULT_CLIENT_ID,
+            CONF_ACCESS_TOKEN: "stored-access",
+            CONF_REFRESH_TOKEN: "stored-refresh",
+        },
+        options={CONF_UPDATE_INTERVAL: 2},
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry) is True
+
+    assert entry.version == 2
+    assert entry.options[CONF_UPDATE_INTERVAL] == 120  # 2h -> 120min
+
+
+async def test_migrate_v1_without_interval_just_bumps_version(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """A v1 entry with no stored update_interval is migrated by version bump only."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=1,
+        title="user@example.com",
+        unique_id="user_example_com",
+        data={
+            CONF_USERNAME: "user@example.com",
+            CONF_PASSWORD: "hunter2",
+            CONF_CUSTOMER_NUMBER: "000000000000",
+            CONF_CLIENT_ID: DEFAULT_CLIENT_ID,
+            CONF_ACCESS_TOKEN: "stored-access",
+            CONF_REFRESH_TOKEN: "stored-refresh",
+        },
+        options={},
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry) is True
+
+    assert entry.version == 2
+    assert CONF_UPDATE_INTERVAL not in entry.options
+
+
+async def test_migrate_v2_is_noop(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """A v2 entry passes straight through the migration unchanged."""
+    entry = _build_entry(hass)
+
+    assert await async_migrate_entry(hass, entry) is True
+
+    assert entry.version == 2
+    assert entry.options[CONF_UPDATE_INTERVAL] == 60


### PR DESCRIPTION
## Summary

Prep work to make the integration eligible for the Home Assistant
[Integration Quality Scale](https://developers.home-assistant.io/docs/core/integration-quality-scale/) Bronze tier. The actual `"quality_scale": "bronze"` manifest declaration is split out into a tiny follow-up PR so this one can be reviewed on its substance.

Audited against all 18 Bronze rules; this PR addresses the two gaps that were blocking declaration:

- **`docs-removal-instructions`** — README had no removal section.
- **`config-flow-test-coverage`** — error/recovery paths and the email/options flows weren't covered.

The other 16 rules were already satisfied by the existing code, the brand assets added in #41, and the audit cleanups in #39 and #40.

## Changes

### `README.md`
Adds a `## Removing the integration` section that describes the standard HA removal flow (Settings → Devices & Services → ⋮ → Delete) and clarifies that no cleanup on engie.be is required (the integration is read-only).

### `custom_components/engie_be/quality_scale.yaml` (new)
Declares the status of all 18 Bronze rules:

- **15 done**: `appropriate-polling`, `brands`, `common-modules`, `config-flow`, `config-flow-test-coverage`, `dependency-transparency`, `docs-high-level-description`, `docs-installation-instructions`, `docs-removal-instructions`, `entity-unique-id`, `has-entity-name`, `runtime-data`, `test-before-configure`, `test-before-setup`, `unique-config-entry`.
- **3 exempt**: `action-setup` and `docs-actions` (no service actions registered) and `entity-event-setup` (entities are coordinator-driven; no library event subscriptions).

### `tests/test_config_flow.py`
Adds gap coverage for every branch in `config_flow.py`:

- Email MFA happy path.
- User-step `connection` and `unknown` errors with explicit recovery (retry succeeds).
- MFA-step `auth`, `connection`, and `unknown` errors.
- Email reauth happy path.
- Reauth-confirm step `auth` (with recovery), `connection`, and `unknown` errors.
- Reauth-MFA step `invalid_mfa_code`, `auth`, `connection`, and `unknown` errors.
- Options flow happy path (interval update) plus bounds validation against `MIN_UPDATE_INTERVAL_MINUTES` / `MAX_UPDATE_INTERVAL_MINUTES`.

### `tests/test_init.py`
Adds three tests for `async_migrate_entry`:

- v1 → v2 with stored `update_interval` in hours converts to minutes (×60).
- v1 → v2 without a stored `update_interval` performs a version-only bump.
- v2 entry passes through unchanged (no-op).

## Verification

- `uvx ruff check` and `uvx ruff format --check` clean.
- New tests follow the existing `pytest_homeassistant_custom_component` patterns already used in `tests/test_config_flow.py` and `tests/test_init.py` (`MockConfigEntry`, `AsyncMock` patches on `EngieBeApiClient.async_start_authentication` / `async_complete_authentication`, `entry.start_reauth_flow(hass)`).

## Follow-up

A one-line PR will add `"quality_scale": "bronze"` to `manifest.json` once this lands.