### PR TITLE
chore: declare Bronze quality scale

### DIFF
--- a/custom_components/engie_be/manifest.json
+++ b/custom_components/engie_be/manifest.json
@@ -9,5 +9,6 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/DaanVervacke/hass-engie-be/issues",
+  "quality_scale": "bronze",
   "version": "0.4.2"
 }


### PR DESCRIPTION
## Summary

Declares the integration at the Bronze tier of the Home Assistant [Integration Quality Scale](https://developers.home-assistant.io/docs/core/integration-quality-scale/) by adding `\"quality_scale\": \"bronze\"` to `manifest.json`.

All 18 Bronze rules are accounted for in `custom_components/engie_be/quality_scale.yaml` (15 `done`, 3 `exempt`), which was added in #42 alongside the docs and test-coverage work that this declaration depends on.

## Verification

Existing CI (Hassfest + ruff + pytest) covers the rules referenced by Bronze. Hassfest validates the `quality_scale` value and the `quality_scale.yaml` manifest.