### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+<!--
+Thanks for contributing! A few notes before you submit:
+
+- Keep the PR focused. Smaller PRs are easier to review and ship.
+- If your change is user-visible, mention it in the README or open a follow-up.
+- Do not bump `manifest.json` `version` unless the maintainer asks you to.
+- Do not commit real customer numbers, tokens, or other personal data.
+-->
+
+## Summary
+
+<!-- One to three sentences: what does this PR do? -->
+
+## Why
+
+<!-- The motivation. What problem does this solve, or what use case does it enable? Link any related issue with `Closes #123` if applicable. -->
+
+## Tests
+
+<!--
+What did you add or change in the test suite? If your change is non-trivial,
+say which tests cover it. Confirm the suite still passes:
+- `scripts/lint` (ruff) clean
+- `pytest` green
+-->
+
+## Verification
+
+<!--
+Manual verification steps you ran, or "N/A, covered by tests".
+For changes that touch the live integration, this might be: started the
+devcontainer, configured the integration, observed expected behavior.
+-->
+
+## Checklist
+
+- [ ] `scripts/lint` passes (or `uvx ruff check .` on the host).
+- [ ] `pytest` passes.
+- [ ] User-visible changes are reflected in `README.md`.
+- [ ] No real customer numbers, tokens, or personal data in the diff.
+- [ ] `manifest.json` version is unchanged (unless the maintainer requested a bump).


### PR DESCRIPTION
## Summary

Adds `.github/pull_request_template.md` so every new PR starts with the
same structure: Summary, Why, Tests, Verification, Checklist. The repo
already has issue templates (`bug.yml`, `feature_request.yml`,
`config.yml`) but had no PR template.

## Why

Recent PRs in this repo have all converged on the same structure
manually. Codifying it as a template:

- Makes review faster (consistent shape, predictable section order).
- Surfaces repo conventions to new contributors via the checklist
  (no manifest version bumps, no personal data, run lint + tests),
  saving them a trip to `AGENTS.md`.
- Matches the structure used by the rest of the Home Assistant
  integration ecosystem.

The template uses HTML comments for guidance so the rendered preview
stays clean once the contributor fills it in.

## Tests

N/A, repo metadata only. No code or test changes.

## Verification

N/A, repo metadata only. The template will render automatically on the
next PR opened against this repo.

## Checklist

- [x] No code touched (lint and tests unaffected).
- [x] User-visible only to contributors (no README change needed).
- [x] No personal data in the diff.
- [x] `manifest.json` version unchanged.