### PR TITLE
perf: fetch service-points in parallel during setup

### DIFF
--- a/custom_components/engie_be/__init__.py
+++ b/custom_components/engie_be/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
@@ -132,23 +133,33 @@ async def async_setup_entry(
     # Fetch initial data and forward platforms
     await coordinator.async_config_entry_first_refresh()
 
-    # Resolve energy type for each EAN via the service-points API
+    # Resolve energy type for each EAN via the service-points API.
+    # Fetched in parallel so multi-EAN customers do not pay sum(latency).
+    eans: list[str] = [
+        item.get("ean", "")
+        for item in (coordinator.data or {}).get("items", [])
+        if item.get("ean")
+    ]
     service_points: dict[str, str] = {}
-    for item in (coordinator.data or {}).get("items", []):
-        ean: str = item.get("ean", "")
-        if not ean:
-            continue
-        try:
-            sp_data = await client.async_get_service_point(ean)
-            division: str = sp_data.get("division", "")
+    if eans:
+        results = await asyncio.gather(
+            *(client.async_get_service_point(ean) for ean in eans),
+            return_exceptions=True,
+        )
+        for ean, result in zip(eans, results, strict=True):
+            if isinstance(result, EngieBeApiClientError):
+                LOGGER.warning(
+                    "Failed to fetch service-point for EAN %s; using fallback",
+                    _hash_ean(ean),
+                )
+                continue
+            if isinstance(result, BaseException):
+                # Re-raise unexpected exceptions; only API errors are tolerated.
+                raise result
+            division: str = result.get("division", "")
             if division:
                 service_points[ean] = division
                 LOGGER.debug("Service-point %s: division=%s", _hash_ean(ean), division)
-        except EngieBeApiClientError:
-            LOGGER.warning(
-                "Failed to fetch service-point for EAN %s; using fallback",
-                _hash_ean(ean),
-            )
     entry.runtime_data.service_points = service_points
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -16,6 +16,7 @@ from custom_components.engie_be import (
 )
 from custom_components.engie_be.api import (
     EngieBeApiClientAuthenticationError,
+    EngieBeApiClientError,
 )
 from custom_components.engie_be.const import (
     CONF_ACCESS_TOKEN,
@@ -379,3 +380,92 @@ async def test_options_change_after_setup_uses_async_reload(
         await async_reload_entry(hass, entry)
 
     mock_reload.assert_awaited_once_with(entry.entry_id)
+
+
+# ---------------------------------------------------------------------------
+# Service-point fan-out: parallel fetch + per-EAN failure isolation
+# ---------------------------------------------------------------------------
+
+
+async def test_setup_entry_fetches_service_points_in_parallel(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """Multi-EAN customers must get one service-point lookup per EAN."""
+    entry = _build_entry(hass)
+    client = _make_client(
+        prices_return={
+            "items": [
+                {"ean": "541448820000000001"},
+                {"ean": "541448820000000002"},
+                {"ean": "541448820000000003"},
+            ],
+        },
+    )
+
+    # Per-EAN service-point responses so we can verify the right division
+    # ends up keyed under the right EAN.
+    division_by_ean = {
+        "541448820000000001": "ELECTRICITY",
+        "541448820000000002": "GAS",
+        "541448820000000003": "ELECTRICITY",
+    }
+
+    async def _service_point(ean: str) -> dict[str, str]:
+        return {"division": division_by_ean[ean]}
+
+    client.async_get_service_point = AsyncMock(side_effect=_service_point)
+
+    with patch(
+        "custom_components.engie_be.EngieBeApiClient",
+        return_value=client,
+    ):
+        ok = await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert ok is True
+    # Every EAN must have been queried exactly once.
+    assert client.async_get_service_point.await_count == 3
+    queried = {call.args[0] for call in client.async_get_service_point.await_args_list}
+    assert queried == set(division_by_ean)
+    # Result dict must reflect each EAN's division.
+    assert entry.runtime_data.service_points == division_by_ean
+
+
+async def test_setup_entry_service_point_failure_does_not_poison_others(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """One failing service-point lookup must not block the surviving EANs."""
+    entry = _build_entry(hass)
+    client = _make_client(
+        prices_return={
+            "items": [
+                {"ean": "541448820000000001"},
+                {"ean": "541448820000000002"},
+                {"ean": "541448820000000003"},
+            ],
+        },
+    )
+
+    async def _service_point(ean: str) -> dict[str, str]:
+        if ean == "541448820000000002":
+            msg = "boom"
+            raise EngieBeApiClientError(msg)
+        return {"division": "ELECTRICITY"}
+
+    client.async_get_service_point = AsyncMock(side_effect=_service_point)
+
+    with patch(
+        "custom_components.engie_be.EngieBeApiClient",
+        return_value=client,
+    ):
+        ok = await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert ok is True
+    # Failing EAN is silently dropped; surviving EANs still resolve.
+    assert entry.runtime_data.service_points == {
+        "541448820000000001": "ELECTRICITY",
+        "541448820000000003": "ELECTRICITY",
+    }


### PR DESCRIPTION
## Summary

Replace the sequential `for ean in eans` loop in `async_setup_entry` with `asyncio.gather(..., return_exceptions=True)` so service-point lookups for multi-EAN customers overlap instead of stacking.

## Why

Single-EAN users see no change. Customers with several meters (electricity + gas, or multiple addresses) currently pay `sum(per-call latency)` on every reload. With `gather` it collapses to roughly the slowest call.

Behaviour preserved:
- Per-EAN `EngieBeApiClientError` is logged at WARNING and the EAN is skipped (same as before).
- EANs with an empty `division` are still skipped.
- Successful lookups still emit the same DEBUG log line with the hashed EAN.

Behaviour tightened:
- Non-API exceptions raised by `async_get_service_point` are now re-raised instead of being swallowed by an over-broad `except`. The previous code only caught `EngieBeApiClientError`, but mixing `return_exceptions=True` with a typed check makes the contract explicit.

## Tests

This code path was previously uncovered: existing tests mock `async_config_entry_first_refresh` to return `None`, leaving `coordinator.data` empty so the loop never ran. Two new tests in `tests/test_init.py` populate prices via the real coordinator update path:

- `test_setup_entry_fetches_service_points_in_parallel` - three EANs, asserts one call per EAN and that divisions land under the right keys.
- `test_setup_entry_service_point_failure_does_not_poison_others` - middle EAN raises `EngieBeApiClientError`, surviving EANs still resolve.

## Verification

- `scripts/lint` (ruff `ALL`) clean
- `pytest tests/` -> 71 passed (was 69)

## Checklist

- [x] Lint passes (`scripts/lint`)
- [x] Tests added/updated
- [x] No user-facing strings changed
- [x] No `manifest.json` version bump (per repo convention)
- [x] CHANGELOG entry will follow once #48 lands