### PR TITLE
docs: point bug template debug-logs link at README troubleshooting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -43,7 +43,7 @@ body:
 - type: textarea
   attributes:
     label: "Debug logs"
-    description: "To enable debug logs check this https://www.home-assistant.io/integrations/logger/, this **needs** to include _everything_ from startup of Home Assistant to the point where you encounter the issue."
+    description: "Follow the step-by-step instructions in the README's [Troubleshooting](https://github.com/DaanVervacke/hass-engie-be#troubleshooting) section to enable debug logging. Logs **need** to include _everything_ from startup of Home Assistant to the point where you encounter the issue."
     render: text
   validations:
     required: true


### PR DESCRIPTION
## Summary

The bug-report issue template's `Debug logs` field linked to the generic Home Assistant logger docs (`/integrations/logger/`). Those docs explain the YAML route but bury the one-click **Enable debug logging** menu that most users actually want.

The README already has a `Troubleshooting` section with both flows spelled out step by step. This PR redirects the template at that section so the instructions live in one place and stay in sync.

## Why

- One source of truth for debug-logging instructions.
- The README walks users through the menu-based flow first (faster, no restart) and falls back to YAML.
- Future updates to the troubleshooting guide automatically benefit issue reporters.

## Tests

N/A, single-line copy change in a YAML issue-form template.

## Verification

- `scripts/lint` clean
- Link target verified: `README.md` line 185 anchor `#troubleshooting`

## Checklist

- [x] Lint passes
- [x] No code changes
- [x] No `manifest.json` version bump (per repo convention)
- [x] CHANGELOG entry will follow if you'd like one under Docs