### PR TITLE
chore: bump minimum Home Assistant version to 2026.3.0

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "engie_be",
-    "image": "mcr.microsoft.com/devcontainers/python:3.13",
+    "image": "mcr.microsoft.com/devcontainers/python:3.14",
     "appPort": [8123],
     "postCreateCommand": "sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg libturbojpeg0 libpcap-dev && scripts/setup",
     "forwardPorts": [

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: "pip"
 
       - name: Install requirements

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: "pip"
 
       - name: Install dependencies

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,6 +1,6 @@
 # The contents of this file is based on https://github.com/home-assistant/core/blob/dev/pyproject.toml
 
-target-version = "py313"
+target-version = "py314"
 
 [lint]
 select = [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Changed
+- Bumped minimum Home Assistant version to 2026.3.0 in hacs.json. The
+  integration's brand icon now ships with the integration itself via the
+  Brands Proxy API (HA 2026.3+), so HACS shows the logo without needing
+  an entry in the upstream brands repo. Users on older Home Assistant
+  versions should stay on 0.5.0 or upgrade Home Assistant ([#53]).
+- Bumped dev/test pins to homeassistant 2026.3.4 and
+  pytest-homeassistant-custom-component 0.13.320 so CI runs at or above
+  the new minimum Home Assistant version ([#53]).
+
 ### Docs
 - README now leads with one-click "Open in HACS" and "Add Integration"
   badges, with the manual steps kept as a fallback ([#52]).
@@ -180,6 +190,7 @@ No user-visible changes.
 [#49]: https://github.com/DaanVervacke/hass-engie-be/pull/49
 [#50]: https://github.com/DaanVervacke/hass-engie-be/pull/50
 [#52]: https://github.com/DaanVervacke/hass-engie-be/pull/52
+[#53]: https://github.com/DaanVervacke/hass-engie-be/pull/53
 
 [Unreleased]: https://github.com/DaanVervacke/hass-engie-be/compare/v0.5.0...HEAD
 [0.5.0]: https://github.com/DaanVervacke/hass-engie-be/compare/v0.4.2...v0.5.0

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "ENGIE Belgium",
   "country": "BE",
-  "homeassistant": "2025.2.4",
+  "homeassistant": "2026.3.0",
   "hacs": "2.0.5",
   "render_readme": true
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-homeassistant==2026.2.3
+homeassistant==2026.3.4
 ruff==0.14.14
 
 # Test dependencies
 # pytest-homeassistant-custom-component is published only on GitHub for 0.13.x
-# Version 0.13.316 matches Home Assistant 2026.2.3
+# Version 0.13.320 matches Home Assistant 2026.3.4
 # Note: pytest-cov is pulled in transitively (==7.0.0) via this package.
-pytest-homeassistant-custom-component @ git+https://github.com/MatthewFlamm/pytest-homeassistant-custom-component@0.13.316
+pytest-homeassistant-custom-component @ git+https://github.com/MatthewFlamm/pytest-homeassistant-custom-component@0.13.320


### PR DESCRIPTION
## Summary

- Raise the minimum supported Home Assistant version to **2026.3.0** in `hacs.json`.
- This unlocks the [Brands Proxy API](https://developers.home-assistant.io/blog/2026/02/24/brands-proxy-api), which serves the integration's own brand assets shipped under `custom_components/engie_be/brand/` (added in #41) directly to HACS, fixing the long-standing "Icon not available" placeholder.
- Bump dev/test pins (`requirements.txt`) to `homeassistant==2026.3.4` and `pytest-homeassistant-custom-component@0.13.320` so CI runs at or above the new minimum.

## Why

The `home-assistant/brands` repository [no longer accepts custom integrations](https://github.com/home-assistant/brands/pull/10225) (our PR there was closed by maintainers). The Brands Proxy API in HA 2026.3+ is now the only supported path for custom integrations to provide their own logo/icon, and it requires the consuming Home Assistant instance to be on that version.

## Breaking change

Users running Home Assistant **older than 2026.3.0** will see this integration flagged as incompatible in HACS and won't be able to install or update past 0.5.0.

Workaround for users on older HA: stay on `0.5.0`, or upgrade Home Assistant.

## What changed

- `hacs.json`: `homeassistant` `2025.2.4` -> `2026.3.0`
- `requirements.txt`: `homeassistant` `2026.2.3` -> `2026.3.4`, matching `pytest-homeassistant-custom-component` `0.13.316` -> `0.13.320`
- `CHANGELOG.md`: documented under `[Unreleased]` `### Changed`

No code or behavior changes. No `manifest.json` `version` bump (kept for the next release PR).

## Note

An earlier revision of this PR also added `min_ha_version` to `manifest.json`, but Hassfest rejected it: that key is only valid for **core** integrations, not custom ones. For custom integrations, HACS handles minimum-HA gating via `hacs.json` alone.