### PR TITLE
docs: require a dedicated ENGIE account to avoid token revocation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -23,6 +23,8 @@ body:
         required: true
       - label: This issue is not a duplicate issue of any [previous issues](https://github.com/DaanVervacke/hass-engie-be/issues?q=is%3Aissue+label%3A%22Bug%22+).
         required: true
+      - label: I am using a dedicated ENGIE account for this integration as required, separate from the account I use for engie.be or the ENGIE Smart App. (See the [README](https://github.com/DaanVervacke/hass-engie-be#prerequisites).)
+        required: true
 - type: textarea
   attributes:
     label: "Describe the issue"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Docs
+- Require a dedicated ENGIE account for this integration. The README,
+  the setup form, the re-authentication dialog, and the bug-report
+  template now state this as a hard requirement rather than a
+  recommendation. Signing into the same ENGIE account from engie.be
+  or the ENGIE Smart App appears to revoke the integration's refresh
+  token. A dedicated account avoids the repeated re-auth prompts
+  ([#55]).
+
 ## [0.6.0] - 2026-04-30
 
 ### Changed
@@ -178,6 +187,7 @@ No user-visible changes.
 [#50]: https://github.com/DaanVervacke/hass-engie-be/pull/50
 [#52]: https://github.com/DaanVervacke/hass-engie-be/pull/52
 [#53]: https://github.com/DaanVervacke/hass-engie-be/pull/53
+[#55]: https://github.com/DaanVervacke/hass-engie-be/pull/55
 
 [Unreleased]: https://github.com/DaanVervacke/hass-engie-be/compare/v0.6.0...HEAD
 [0.6.0]: https://github.com/DaanVervacke/hass-engie-be/compare/v0.5.0...v0.6.0

--- a/README.md
+++ b/README.md
@@ -104,7 +104,17 @@ the ENGIE API.
 
 ## Prerequisites
 
-- An active [ENGIE Belgium](https://www.engie.be/) account
+> **Required:** This integration requires a dedicated ENGIE account.
+> Do not use the same ENGIE account you use to sign into
+> [engie.be](https://www.engie.be/) or the ENGIE Smart App. Signing
+> into the same ENGIE account from another place appears to revoke
+> the integration's refresh token, which forces Home Assistant to
+> prompt you for re-authentication. Create a separate user via the
+> [ENGIE user management page](https://www.engie.be/nl/energiedesk/usermanagement/manage-access/)
+> and grant it access to your customer number.
+
+- A dedicated [ENGIE Belgium](https://www.engie.be/) account for this
+  integration (see required callout above)
 - Your ENGIE customer number (business agreement number)
 - Access to SMS or email for two-factor authentication during setup
 
@@ -138,7 +148,11 @@ If the badges above do not work in your browser:
 
 Before starting, there are a few things to note:
 
-This integration only works for accounts where 2FA via SMS or e-mail is already enabled. If ENGIE has not yet enforced 2FA for your account, please visit <https://www.engie.be/nl/energiedesk/usermanagement/manage-access/> and create a new separate user for this integration. New accounts have 2FA enabled by default and will work with this integration. If your account already has 2FA enabled but you still get authentication errors, please try this method as well.
+**A dedicated ENGIE account is required for this integration** (see
+[Prerequisites](#prerequisites) for the reasoning). New accounts
+created via the [ENGIE user management page](https://www.engie.be/nl/energiedesk/usermanagement/manage-access/)
+have 2FA enabled by default and work out of the box. The integration
+only supports accounts where 2FA via SMS or e-mail is already enabled.
 
 Configuration is done entirely through the Home Assistant UI. If you
 haven't reached the credential form yet, use the **Add Integration**
@@ -171,9 +185,10 @@ After setup, you can configure the price update interval:
 ## Re-authentication
 
 ENGIE rotates refresh tokens regularly, and the upstream auth server can
-revoke a session at any time (for example, when the same account logs in
-elsewhere). When that happens, Home Assistant will surface a **"Repair"**
-notification asking you to re-authenticate.
+revoke a session at any time. The most common trigger is the same ENGIE
+account being used elsewhere (engie.be web, ENGIE Smart App). If you see
+the **"Repair"** notification frequently, see
+[Prerequisites](#prerequisites) for the dedicated-account recommendation.
 
 To complete re-authentication:
 
@@ -183,7 +198,7 @@ To complete re-authentication:
 2. Choose how you want to receive a verification code (SMS or email).
 3. Enter the 6-digit code that ENGIE sends you.
 
-Your stored email, password, and customer number are reused; only fresh
+Your stored email, password, and customer number are reused. Only fresh
 access and refresh tokens are written back to the config entry. No
 sensors are removed and no history is lost.
 
@@ -229,7 +244,10 @@ filing an issue:
 3. **Common errors.**
    - *Authentication with ENGIE Belgium failed*: your stored tokens
      were rejected. Follow the [Re-authentication](#re-authentication)
-     steps above.
+     steps above. If this happens repeatedly, the most common cause is
+     sharing your ENGIE account between this integration and engie.be
+     or the ENGIE Smart App. A dedicated account is required. See
+     [Prerequisites](#prerequisites).
    - *Cannot connect to the ENGIE Belgium API*: the upstream API is
      unreachable or returned an HTTP error. The coordinator will retry
      on its next interval.

--- a/custom_components/engie_be/strings.json
+++ b/custom_components/engie_be/strings.json
@@ -2,7 +2,7 @@
     "config": {
         "step": {
             "user": {
-                "description": "Enter your ENGIE Belgium account credentials and customer number, and choose your preferred two-factor authentication method. This integration only works for accounts where 2FA via SMS or e-mail is already enabled. If ENGIE has not yet enforced 2FA for your account, please visit the [ENGIE user management page]({user_management_url}) and create a new separate user for this integration. New accounts have 2FA enabled by default and will work with this integration. If your account already has 2FA enabled but you still get authentication errors, please try this method as well.",
+                "description": "Enter your ENGIE Belgium credentials, customer number, and two-factor authentication method. **A dedicated ENGIE account is required**: signing into the same account from engie.be or the ENGIE Smart App appears to revoke the integration's session and force you to re-authenticate. Create a separate user via the [ENGIE user management page]({user_management_url}). New accounts have 2FA enabled by default and work out of the box.",
                 "data": {
                     "username": "Email address",
                     "password": "Password",
@@ -13,7 +13,7 @@
                 "data_description": {
                     "username": "Your ENGIE Belgium account email address.",
                     "password": "Your ENGIE Belgium account password.",
-                    "customer_number": "Enter your ENGIE Belgium customer number as shown in the ENGIE Smart app. The 00 prefix is added automatically.",
+                    "customer_number": "Enter your ENGIE Belgium customer number as shown in the ENGIE Smart App. The 00 prefix is added automatically.",
                     "client_id": "OAuth client ID. Only change this if you know what you are doing.",
                     "mfa_method": "Choose how you want to receive your verification code."
                 }
@@ -38,7 +38,7 @@
             },
             "reauth_confirm": {
                 "title": "Reauthenticate ENGIE Belgium",
-                "description": "Your stored ENGIE access has expired for {username}. Choose how you want to receive a new verification code to re-authenticate.",
+                "description": "Your stored ENGIE access has expired for {username}. Choose how you want to receive a new verification code to re-authenticate. If this prompt keeps reappearing, the most common cause is sharing your ENGIE account between this integration and engie.be or the ENGIE Smart App. A dedicated ENGIE account is required for this integration. See the integration documentation.",
                 "data": {
                     "mfa_method": "Two-factor authentication method"
                 },
@@ -73,7 +73,7 @@
             "message": "Cannot connect to the ENGIE Belgium API."
         },
         "auth_failed": {
-            "message": "Authentication with ENGIE Belgium failed; please re-authenticate."
+            "message": "Authentication with ENGIE Belgium failed. Please re-authenticate."
         },
         "unknown_error": {
             "message": "An unknown error occurred while talking to the ENGIE Belgium API."

--- a/custom_components/engie_be/translations/en.json
+++ b/custom_components/engie_be/translations/en.json
@@ -2,7 +2,7 @@
     "config": {
         "step": {
             "user": {
-                "description": "Enter your ENGIE Belgium account credentials and customer number, and choose your preferred two-factor authentication method. This integration only works for accounts where 2FA via SMS or e-mail is already enabled. If ENGIE has not yet enforced 2FA for your account, please visit the [ENGIE user management page]({user_management_url}) and create a new separate user for this integration. New accounts have 2FA enabled by default and will work with this integration. If your account already has 2FA enabled but you still get authentication errors, please try this method as well.",
+                "description": "Enter your ENGIE Belgium credentials, customer number, and two-factor authentication method. **A dedicated ENGIE account is required**: signing into the same account from engie.be or the ENGIE Smart App appears to revoke the integration's session and force you to re-authenticate. Create a separate user via the [ENGIE user management page]({user_management_url}). New accounts have 2FA enabled by default and work out of the box.",
                 "data": {
                     "username": "Email address",
                     "password": "Password",
@@ -13,7 +13,7 @@
                 "data_description": {
                     "username": "Your ENGIE Belgium account email address.",
                     "password": "Your ENGIE Belgium account password.",
-                    "customer_number": "Enter your ENGIE Belgium customer number as shown in the ENGIE Smart app. The 00 prefix is added automatically.",
+                    "customer_number": "Enter your ENGIE Belgium customer number as shown in the ENGIE Smart App. The 00 prefix is added automatically.",
                     "client_id": "OAuth client ID. Only change this if you know what you are doing.",
                     "mfa_method": "Choose how you want to receive your verification code."
                 }
@@ -38,7 +38,7 @@
             },
             "reauth_confirm": {
                 "title": "Reauthenticate ENGIE Belgium",
-                "description": "Your stored ENGIE access has expired for {username}. Choose how you want to receive a new verification code to re-authenticate.",
+                "description": "Your stored ENGIE access has expired for {username}. Choose how you want to receive a new verification code to re-authenticate. If this prompt keeps reappearing, the most common cause is sharing your ENGIE account between this integration and engie.be or the ENGIE Smart App. A dedicated ENGIE account is required for this integration. See the integration documentation.",
                 "data": {
                     "mfa_method": "Two-factor authentication method"
                 },
@@ -73,7 +73,7 @@
             "message": "Cannot connect to the ENGIE Belgium API."
         },
         "auth_failed": {
-            "message": "Authentication with ENGIE Belgium failed; please re-authenticate."
+            "message": "Authentication with ENGIE Belgium failed. Please re-authenticate."
         },
         "unknown_error": {
             "message": "An unknown error occurred while talking to the ENGIE Belgium API."


### PR DESCRIPTION
## Summary

- Make a dedicated ENGIE account a **hard requirement** for this integration on every surface a user actually reads: the README Prerequisites callout and bullet, README Configuration intro, README Re-authentication paragraph, README Troubleshooting bullet, the config-flow setup form, the re-authentication dialog, and the bug-report template checkbox.
- Frame it around the working theory that signing into the same ENGIE account from engie.be or the ENGIE Smart App appears to revoke the integration's refresh token. Hedged ("appears to revoke") rather than asserted as confirmed root cause.
- Style sweep on all touched strings: ENGIE brand always in all-caps (including `ENGIE Smart App`); no semicolons splitting sentences; tightened the "and"-heavy setup form opener.
- No code changes. No `manifest.json` version bump.

## Why

The previous copy framed a separate account as a conditional fallback for users whose accounts didn't yet have 2FA enforced ("If ENGIE has not yet enforced 2FA..."). In practice, users running the integration on their main account see frequent re-auth prompts regardless of 2FA state. Making a dedicated account a hard requirement up front turns this into a one-time install step rather than a recurring annoyance, and the bug-report template's required checkbox enforces it at issue-filing time.

## What changed since first review

This PR was originally drafted as a recommendation (`> **Important:** Use a dedicated ENGIE account...`). On second pass the bar was raised to a hard requirement to prevent recurring re-auth bug reports rooted in shared-account use:
- `> **Important:**` callout → `> **Required:**`
- README Prerequisites bullet "ideally dedicated" → "A dedicated ... account for this integration"
- Setup form copy "Use a dedicated ENGIE account for this integration" → "A dedicated ENGIE account is required"
- Bug-report checkbox "I am using a dedicated ENGIE account" → "I am using a dedicated ENGIE account for this integration as required"
- A style sweep also fixed brand caps (`Engie Smart App` → `ENGIE Smart App`, including a pre-existing inconsistency in the `customer_number` hint), tightened the setup form opener from 22 words / 3 "and"s to 14 words / 1 "and", and replaced sentence-splitting semicolons with periods across all touched strings.

## Files

- `README.md` — new `> **Required:**` callout in Prerequisites; Prerequisites bullet rewritten as a dedicated-account requirement; tightened Configuration opener; strengthened Re-authentication paragraph; appended note to the "Authentication failed" troubleshooting bullet; brand caps fixed; sentence-splitting semicolons replaced.
- `custom_components/engie_be/strings.json` — rewrote `config.step.user.description` (lead with the requirement, tightened opener, brand caps, no semicolons); appended a requirement hint to `config.step.reauth_confirm.description`; brand caps fix in `config.step.user.data.customer_number`; semicolon replaced in `exceptions.auth.message`.
- `custom_components/engie_be/translations/en.json` — mirrors `strings.json` exactly.
- `.github/ISSUE_TEMPLATE/bug.yml` — added a required checkbox so bug reports must acknowledge the dedicated-account requirement; brand caps fix.
- `CHANGELOG.md` — added entry under `[Unreleased]` `### Docs`; brand caps and semicolon-as-period fixes in the new entry.

## Out of scope

- Native-language (nl/fr) translations. Discussed and intentionally deferred. The integration ships English-only today; a follow-up can add full translations or accept community contributions.
- `manifest.json` version bump. Rolls into the next release PR per repo convention.
- The single remaining semicolon at `CHANGELOG.md:73` is from the released v0.4.x history and is intentionally not rewritten.