### PR TITLE
docs: describe captar feature outside the dedicated section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,9 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ### Docs
 - README updated to describe the captar feature outside the per-PR
-  section: intro, Features list, Sensors-intro, Configuration
-  walkthrough, and How-it-works now mention the second endpoint and
-  the captar sensors. Captar section gained a one-paragraph caveat
+  section: intro, features list, sensors intro, configuration
+  walkthrough, and how-it-works now mention the second endpoint and
+  the captar sensors. The captar section gained a one-paragraph caveat
   covering always-created behaviour, per-EAN emission, the deliberate
   non-Energy-dashboard choice, and the intentional omission of daily
   peak entries ([#59]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
   two attributes (`peak_month` and `peak_is_fallback`) so the source
   of the displayed value is explicit ([#58]).
 
+### Docs
+- README updated to describe the captar feature outside the per-PR
+  section: intro, Features list, Sensors-intro, Configuration
+  walkthrough, and How-it-works now mention the second endpoint and
+  the captar sensors. Captar section gained a one-paragraph caveat
+  covering always-created behaviour, per-EAN emission, the deliberate
+  non-Energy-dashboard choice, and the intentional omission of daily
+  peak entries ([#59]).
+
 ## [0.6.1] - 2026-05-01
 
 ### Docs
@@ -205,6 +214,7 @@ No user-visible changes.
 [#53]: https://github.com/DaanVervacke/hass-engie-be/pull/53
 [#55]: https://github.com/DaanVervacke/hass-engie-be/pull/55
 [#58]: https://github.com/DaanVervacke/hass-engie-be/pull/58
+[#59]: https://github.com/DaanVervacke/hass-engie-be/pull/59
 
 [Unreleased]: https://github.com/DaanVervacke/hass-engie-be/compare/v0.6.1...HEAD
 [0.6.1]: https://github.com/DaanVervacke/hass-engie-be/compare/v0.6.0...v0.6.1

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 Custom [Home Assistant](https://www.home-assistant.io/) integration for
 [ENGIE Belgium](https://www.engie.be/). Retrieves your personal energy price
-data from the ENGIE Belgium API and exposes it as sensors.
+data and monthly capacity-tariff peaks from the ENGIE Belgium API and exposes
+them as sensors.
 
 ## A note on how this was built
 
@@ -22,18 +23,22 @@ before release.
 - Detects gas and electricity contracts via the ENGIE service-points endpoint
 - Creates price sensors per energy type, direction (offtake / injection), and
   tariff rate (single-rate, dual-rate, or tri-rate contracts)
+- Tracks the monthly capacity-tariff (captar) peak window per electricity service point
 - Configurable update interval via the integration options
 
 ## Sensors
 
-The integration auto-detects your energy contracts and creates sensors
-accordingly. All price sensors are in **EUR/kWh** with 6 decimal precision.
-Each sensor exposes the following attributes: `ean`, `from`, `to`,
-`vat_tariff`, `time_of_use_slot_code`, and `last_fetched`.
+The integration auto-detects your energy contracts and creates price sensors
+accordingly. Capacity-tariff peak sensors are created independently when peaks
+data is available; see [Capacity tariff (captar)](#capacity-tariff-captar).
 
-Which sensors are created depends on your contract type. The integration reads
-the `timeOfUseSlotCode` from the API response to determine whether you have a
-single-rate, dual-rate (peak / off-peak), or tri-rate
+**Price sensors** are in **EUR/kWh** with 6 decimal precision. Each one exposes
+the following attributes: `ean`, `from`, `to`, `vat_tariff`,
+`time_of_use_slot_code`, and `last_fetched`.
+
+Which price sensors are created depends on your contract type. The integration
+reads the `timeOfUseSlotCode` from the API response to determine whether you
+have a single-rate, dual-rate (peak / off-peak), or tri-rate
 (peak / off-peak / super off-peak) contract.
 
 ### Gas
@@ -108,6 +113,12 @@ capacity-tariff calculation. Values come from the ENGIE
 | Captar monthly peak energy | `sensor.engie_belgium_captar_monthly_peak_energy` | Energy consumed during that 15-minute window, in kWh |
 | Captar monthly peak start | `sensor.engie_belgium_captar_monthly_peak_start` | Start timestamp of the 15-minute peak window |
 | Captar monthly peak end | `sensor.engie_belgium_captar_monthly_peak_end` | End timestamp of the 15-minute peak window |
+
+These sensors are always created when peaks data is available, are emitted per
+electricity EAN, and are not intended as Energy-dashboard sources (the kW and
+kWh values use `state_class=measurement` because they describe a 15-minute peak
+window, not a cumulative counter). Daily peak entries returned by the same
+endpoint are intentionally not exposed as sensors.
 
 The ENGIE API only returns a monthly peak after the first 15-minute peak
 of the month has been recorded, which means the current month is empty
@@ -192,8 +203,8 @@ for **ENGIE Belgium**.
 2. Click **Submit** - you will receive a verification code via your chosen method
 3. Enter the 6-digit verification code and click **Submit**
 
-The integration will authenticate, fetch your energy prices, and create the
-appropriate sensors.
+The integration will authenticate, fetch your energy prices and capacity-tariff
+peaks, and create the appropriate sensors.
 
 ### Options
 
@@ -309,8 +320,11 @@ safe to share.
 - **Token refresh**: Access tokens expire in ~2 minutes. The integration
   refreshes tokens every 60 seconds automatically. Refresh tokens are rotated
   and persisted to the config entry.
-- **Data polling**: Energy prices are fetched at the configured interval
-  (default: every 60 minutes). The coordinator makes a single API call per update.
+- **Data polling**: Energy prices and the current month's capacity-tariff peak
+  are fetched at the configured interval (default: every 60 minutes). The
+  coordinator polls two endpoints per update; if the peaks endpoint fails
+  transiently, the previous value is preserved so the captar sensors stay
+  populated.
 - **Energy type detection**: At startup the integration calls the ENGIE
   service-points endpoint for each EAN to determine whether the contract is gas
   or electricity. If the lookup fails, a generic "Energy" label is used as


### PR DESCRIPTION
## Summary

- Refresh the README spots that still framed the integration as price-only after PR #58 shipped the captar sensors: intro line, Features list, Sensors-intro, Configuration walkthrough step 3, and the How-it-works data-polling bullet.
- Add a one-paragraph caveat under the captar four-sensor table covering: always-created when peaks data is present, per-electricity-EAN emission, deliberate non-Energy-dashboard choice (kW / kWh use `state_class=measurement` because the value is a 15-minute window measurement, not a counter), and intentional omission of the daily peak entries returned by the same endpoint.
- Bump version `0.6.1` -> `0.6.2` (PATCH, docs-only).

## Why

PR #58 added the captar sensors and its own README subsection, but did not touch the rest of the document. A first-time reader still sees "Retrieves your personal energy price data ... and exposes it as sensors", a Features list with no peaks bullet, and a Sensors intro that claims "All price sensors are in EUR/kWh ..." with a universal attribute list that does not apply to the captar entities. This PR fixes that framing so the integration is described as prices + capacity-tariff peaks throughout.

## Notes

- No code, schema, or string changes. Translations untouched.
- No new sections. Edits stay inline in existing sections to keep anchor links stable.
- The captar caveats use compact prose under the existing table per the agreed scope, not a new subsection.

## Verification

- `uvx ruff check custom_components/engie_be` passes (no Python changes, sanity check).
- Manual diff review for em-dashes and `status.engie.be` references (none introduced).
- Captar section's `#capacity-tariff-captar` anchor preserved; the new forward reference in the Sensors intro links to it.

Refs #58