### PR TITLE
debug: log happy-hour-event endpoint response (do not merge)

### DIFF
--- a/custom_components/engie_be/api.py
+++ b/custom_components/engie_be/api.py
@@ -18,6 +18,7 @@ import aiohttp
 from .const import (
     API_BASE_URL,
     AUTH_BASE_URL,
+    HAPPY_HOUR_BASE_URL,
     LOGGER,
     MFA_METHOD_SMS,
     OAUTH_AUDIENCE,
@@ -322,6 +323,35 @@ class EngieBeApiClient:
             url=url,
             headers=headers,
             params={"year": str(year), "month": str(month)},
+            json_response=True,
+        )
+
+    async def async_get_happy_hour_event(
+        self,
+        customer_number: str,
+    ) -> Any:
+        """
+        Fetch the happy-hour event payload for a given customer.
+
+        Debug-only helper for the ``debug/happy-hour-event`` branch.
+        Returns the raw parsed JSON (or text, if not JSON) so it can be
+        logged verbatim and shared with the integration author.
+        """
+        url = (
+            f"{HAPPY_HOUR_BASE_URL}/business-agreements/"
+            f"{customer_number.replace(' ', '')}/happy-hour-event"
+        )
+        headers = {
+            "User-Agent": USER_AGENT_NATIVE,
+            "Accept": "application/json, application/problem+json",
+            "authorization": f"Bearer {self.access_token}",
+            "x-trace-id": str(uuid.uuid4()),
+        }
+        return await self._api_wrapper(
+            session=self._session,
+            method="GET",
+            url=url,
+            headers=headers,
             json_response=True,
         )
 

--- a/custom_components/engie_be/api.py
+++ b/custom_components/engie_be/api.py
@@ -1019,10 +1019,10 @@ class EngieBeApiClient:
 
     async def async_get_happy_hour_event(
         self,
-        customer_number: str,
+        business_agreement_number: str,
     ) -> Any:
         """
-        Fetch the happy-hour event payload for a given customer.
+        Fetch the happy-hour event payload for a given business agreement.
 
         Debug-only helper for the ``debug/happy-hour-event`` branch.
         Returns the raw parsed JSON (or text, if not JSON) so it can be
@@ -1030,7 +1030,7 @@ class EngieBeApiClient:
         """
         url = (
             f"{HAPPY_HOUR_BASE_URL}/business-agreements/"
-            f"{customer_number.replace(' ', '')}/happy-hour-event"
+            f"{business_agreement_number.replace(' ', '')}/happy-hour-event"
         )
         headers = {
             "User-Agent": USER_AGENT_NATIVE,

--- a/custom_components/engie_be/api.py
+++ b/custom_components/engie_be/api.py
@@ -27,6 +27,7 @@ from .const import (
     AUTH_BASE_URL,
     BUSINESS_AGREEMENTS_BASE_URL,
     EPEX_BASE_URL,
+    HAPPY_HOUR_BASE_URL,
     LOGGER,
     MFA_METHOD_SMS,
     OAUTH_AUDIENCE,
@@ -1015,6 +1016,35 @@ class EngieBeApiClient:
                 f"({exception.__class__.__name__})"
             )
             raise EngieBeApiClientCommunicationError(msg) from exception
+
+    async def async_get_happy_hour_event(
+        self,
+        customer_number: str,
+    ) -> Any:
+        """
+        Fetch the happy-hour event payload for a given customer.
+
+        Debug-only helper for the ``debug/happy-hour-event`` branch.
+        Returns the raw parsed JSON (or text, if not JSON) so it can be
+        logged verbatim and shared with the integration author.
+        """
+        url = (
+            f"{HAPPY_HOUR_BASE_URL}/business-agreements/"
+            f"{customer_number.replace(' ', '')}/happy-hour-event"
+        )
+        headers = {
+            "User-Agent": USER_AGENT_NATIVE,
+            "Accept": "application/json, application/problem+json",
+            "authorization": f"Bearer {self.access_token}",
+            "x-trace-id": str(uuid.uuid4()),
+        }
+        return await self._api_wrapper(
+            session=self._session,
+            method="GET",
+            url=url,
+            headers=headers,
+            json_response=True,
+        )
 
     # ------------------------------------------------------------------
     # Internal: auth flow step implementations

--- a/custom_components/engie_be/const.py
+++ b/custom_components/engie_be/const.py
@@ -14,6 +14,7 @@ AUTH_BASE_URL = "https://account.engie.be"
 API_BASE_URL = "https://www.engie.be/api/engie/be/ms/billing/customer/v1"
 PREMISES_BASE_URL = "https://www.engie.be/api/engie/be/ms/premises/customer/v1"
 PEAKS_BASE_URL = "https://api.engie.be/engie/ms/b2c-energy-insights/v1"
+HAPPY_HOUR_BASE_URL = "https://api.engie.be/engie/ms/energy-insights/customer/v1"
 
 # OAuth configuration (public mobile-app client, no secret needed)
 DEFAULT_CLIENT_ID = "R0PQyUdjO5B2tBaRnltgitVnnUmjGyld"

--- a/custom_components/engie_be/const.py
+++ b/custom_components/engie_be/const.py
@@ -14,6 +14,7 @@ AUTH_BASE_URL = "https://account.engie.be"
 API_BASE_URL = "https://www.engie.be/api/engie/be/ms/billing/customer/v1"
 PREMISES_BASE_URL = "https://www.engie.be/api/engie/be/ms/premises/customer/v1"
 PEAKS_BASE_URL = "https://api.engie.be/engie/ms/b2c-energy-insights/v1"
+HAPPY_HOUR_BASE_URL = "https://api.engie.be/engie/ms/energy-insights/customer/v1"
 ACCOUNTS_BASE_URL = "https://api.engie.be/engie/ms/accounts/customer/v1"
 BUSINESS_AGREEMENTS_BASE_URL = (
     "https://www.engie.be/api/engie/be/ms/business-agreements/customer/v1"

--- a/custom_components/engie_be/coordinator.py
+++ b/custom_components/engie_be/coordinator.py
@@ -98,8 +98,39 @@ class EngieBeDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             data["peaks"] = peaks_wrapper
             self._record_peak_history(peaks_wrapper)
 
+        # Debug-only: probe the happy-hour-event endpoint and log the
+        # raw response so users can share it with the integration author.
+        # This branch (`debug/happy-hour-event`) is not meant to be merged.
+        await self._async_log_happy_hour_event(client, customer_number)
+
         self.last_successful_fetch = dt_util.utcnow()
         return data
+
+    async def _async_log_happy_hour_event(
+        self,
+        client: Any,
+        customer_number: str,
+    ) -> None:
+        """Fetch the happy-hour-event endpoint and log the raw response."""
+        try:
+            response = await client.async_get_happy_hour_event(customer_number)
+        except EngieBeApiClientAuthenticationError as exception:
+            LOGGER.warning(
+                "happy-hour-event probe failed (auth): %s",
+                exception,
+            )
+            return
+        except EngieBeApiClientError as exception:
+            LOGGER.warning(
+                "happy-hour-event probe failed: %s",
+                exception,
+            )
+            return
+
+        LOGGER.warning(
+            "happy-hour-event response (please share with the integration author): %r",
+            response,
+        )
 
     def _record_peak_history(self, peaks_wrapper: dict[str, Any]) -> None:
         """Persist the current month's peak window if it is not a fallback."""

--- a/custom_components/engie_be/coordinator.py
+++ b/custom_components/engie_be/coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -127,9 +128,20 @@ class EngieBeDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
             return
 
+        try:
+            payload = json.dumps(response, ensure_ascii=False, sort_keys=True)
+        except (TypeError, ValueError) as exception:
+            LOGGER.warning(
+                "happy-hour-event response could not be JSON-serialised "
+                "(%s); raw value: %r",
+                exception,
+                response,
+            )
+            return
+
         LOGGER.warning(
-            "happy-hour-event response (please share with the integration author): %r",
-            response,
+            "happy-hour-event response (please share with the integration author): %s",
+            payload,
         )
 
     def _record_peak_history(self, peaks_wrapper: dict[str, Any]) -> None:

--- a/custom_components/engie_be/coordinator.py
+++ b/custom_components/engie_be/coordinator.py
@@ -208,7 +208,7 @@ class EngieBeDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Debug-only: probe the happy-hour-event endpoint and log the
         # raw response so users can share it with the integration author.
         # This branch (`debug/happy-hour-event`) is not meant to be merged.
-        await self._async_log_happy_hour_event(client, self.customer_number)
+        await self._async_log_happy_hour_event(client, self.business_agreement_number)
 
         self.last_successful_fetch = dt_util.utcnow()
         return data
@@ -216,11 +216,13 @@ class EngieBeDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def _async_log_happy_hour_event(
         self,
         client: Any,
-        customer_number: str,
+        business_agreement_number: str,
     ) -> None:
         """Fetch the happy-hour-event endpoint and log the raw response."""
         try:
-            response = await client.async_get_happy_hour_event(customer_number)
+            response = await client.async_get_happy_hour_event(
+                business_agreement_number,
+            )
         except EngieBeApiClientAuthenticationError as exception:
             LOGGER.warning(
                 "happy-hour-event probe failed (auth): %s",

--- a/custom_components/engie_be/coordinator.py
+++ b/custom_components/engie_be/coordinator.py
@@ -204,8 +204,39 @@ class EngieBeDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             data["peaks"] = peaks_wrapper
             self._record_peak_history(peaks_wrapper)
 
+        # Debug-only: probe the happy-hour-event endpoint and log the
+        # raw response so users can share it with the integration author.
+        # This branch (`debug/happy-hour-event`) is not meant to be merged.
+        await self._async_log_happy_hour_event(client, self.customer_number)
+
         self.last_successful_fetch = dt_util.utcnow()
         return data
+
+    async def _async_log_happy_hour_event(
+        self,
+        client: Any,
+        customer_number: str,
+    ) -> None:
+        """Fetch the happy-hour-event endpoint and log the raw response."""
+        try:
+            response = await client.async_get_happy_hour_event(customer_number)
+        except EngieBeApiClientAuthenticationError as exception:
+            LOGGER.warning(
+                "happy-hour-event probe failed (auth): %s",
+                exception,
+            )
+            return
+        except EngieBeApiClientError as exception:
+            LOGGER.warning(
+                "happy-hour-event probe failed: %s",
+                exception,
+            )
+            return
+
+        LOGGER.warning(
+            "happy-hour-event response (please share with the integration author): %r",
+            response,
+        )
 
     def _record_peak_history(self, peaks_wrapper: dict[str, Any]) -> None:
         """Persist the current month's peak window if it is not a fallback."""

--- a/custom_components/engie_be/coordinator.py
+++ b/custom_components/engie_be/coordinator.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from datetime import datetime, time, timedelta
 from typing import TYPE_CHECKING, Any
 from zoneinfo import ZoneInfo
@@ -25,6 +24,7 @@ from .api import (
     EngieBeApiClientAuthenticationError,
     EngieBeApiClientError,
     EpexNotPublishedError,
+    _redact_body,
 )
 from .const import (
     CONF_BUSINESS_AGREEMENT_NUMBER,
@@ -205,23 +205,33 @@ class EngieBeDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             data["peaks"] = peaks_wrapper
             self._record_peak_history(peaks_wrapper)
 
-        # Debug-only: probe the happy-hour-event endpoint and log the
-        # raw response so users can share it with the integration author.
-        # This branch (`debug/happy-hour-event`) is not meant to be merged.
-        await self._async_log_happy_hour_event(client, self.business_agreement_number)
+        # Debug-only: probe the happy-hour-event endpoint on every
+        # refresh and log the redacted response so users can share it
+        # with the integration author. Happy-hour windows are time-
+        # bounded, so a one-shot probe at startup would miss any user
+        # who restarts HA outside an active window. This branch
+        # (`debug/happy-hour-event`) is not meant to be merged.
+        await self._async_log_happy_hour_event(client)
 
         self.last_successful_fetch = dt_util.utcnow()
         return data
 
-    async def _async_log_happy_hour_event(
-        self,
-        client: Any,
-        business_agreement_number: str,
-    ) -> None:
-        """Fetch the happy-hour-event endpoint and log the raw response."""
+    async def _async_log_happy_hour_event(self, client: EngieBeApiClient) -> None:
+        """
+        Fetch the happy-hour-event endpoint and log the redacted response.
+
+        Failure paths stay at WARNING because they surface a real
+        upstream problem worth user attention. The success path logs at
+        DEBUG (per HA Labs guidance for non-critical preview-feature
+        diagnostics) and routes the response through ``_redact_body``
+        so account-identifying fields (``businessAgreementNumber``,
+        ``ean``, ``customerAccountNumber``, address fragments, ...)
+        are masked the same way as the existing wire-format
+        ``← OK`` debug line.
+        """
         try:
             response = await client.async_get_happy_hour_event(
-                business_agreement_number,
+                self.business_agreement_number,
             )
         except EngieBeApiClientAuthenticationError as exception:
             LOGGER.warning(
@@ -236,20 +246,9 @@ class EngieBeDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
             return
 
-        try:
-            payload = json.dumps(response, ensure_ascii=False, sort_keys=True)
-        except (TypeError, ValueError) as exception:
-            LOGGER.warning(
-                "happy-hour-event response could not be JSON-serialised "
-                "(%s); raw value: %r",
-                exception,
-                response,
-            )
-            return
-
-        LOGGER.warning(
+        LOGGER.debug(
             "happy-hour-event response (please share with the integration author): %s",
-            payload,
+            _redact_body(response, "application/json"),
         )
 
     def _record_peak_history(self, peaks_wrapper: dict[str, Any]) -> None:

--- a/custom_components/engie_be/coordinator.py
+++ b/custom_components/engie_be/coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, time, timedelta
 from typing import TYPE_CHECKING, Any
 from zoneinfo import ZoneInfo
@@ -233,9 +234,20 @@ class EngieBeDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
             return
 
+        try:
+            payload = json.dumps(response, ensure_ascii=False, sort_keys=True)
+        except (TypeError, ValueError) as exception:
+            LOGGER.warning(
+                "happy-hour-event response could not be JSON-serialised "
+                "(%s); raw value: %r",
+                exception,
+                response,
+            )
+            return
+
         LOGGER.warning(
-            "happy-hour-event response (please share with the integration author): %r",
-            response,
+            "happy-hour-event response (please share with the integration author): %s",
+            payload,
         )
 
     def _record_peak_history(self, peaks_wrapper: dict[str, Any]) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -83,6 +83,7 @@ async def test_async_update_data_returns_payload_on_success(
     client = MagicMock()
     client.async_get_prices = AsyncMock(return_value=payload)
     client.async_get_monthly_peaks = AsyncMock(return_value=peaks_payload)
+    client.async_get_happy_hour_event = AsyncMock(return_value={})
     _attach_runtime(entry, client)
 
     coordinator = EngieBeDataUpdateCoordinator(hass=hass, config_entry=entry)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -112,6 +112,7 @@ async def test_async_update_data_returns_payload_on_success(
     client = MagicMock()
     client.async_get_prices = AsyncMock(return_value=payload)
     client.async_get_monthly_peaks = AsyncMock(return_value=peaks_payload)
+    client.async_get_happy_hour_event = AsyncMock(return_value={})
     _attach_runtime(entry, client)
 
     coordinator = EngieBeDataUpdateCoordinator(

--- a/tests/test_coordinator_backfill.py
+++ b/tests/test_coordinator_backfill.py
@@ -103,6 +103,9 @@ def _make_client(
     client.async_get_monthly_peaks = AsyncMock(
         return_value={"peakOfTheMonth": None, "dailyPeaks": []},
     )
+    # Debug-only probe (debug/happy-hour-event branch); stub so coordinator
+    # doesn't try to await a bare MagicMock.
+    client.async_get_happy_hour_event = AsyncMock(return_value={})
     if relations_side_effect is not None:
         client.async_get_customer_account_relations = AsyncMock(
             side_effect=relations_side_effect,

--- a/tests/test_coordinator_dynamic.py
+++ b/tests/test_coordinator_dynamic.py
@@ -101,6 +101,9 @@ def _build_dynamic_client() -> MagicMock:
     client = MagicMock()
     client.async_get_prices = AsyncMock(return_value={"items": []})
     client.async_get_monthly_peaks = AsyncMock(return_value=peaks)
+    # Debug-only probe (debug/happy-hour-event branch); stub so coordinator
+    # doesn't try to await a bare MagicMock.
+    client.async_get_happy_hour_event = AsyncMock(return_value={})
     return client
 
 
@@ -141,6 +144,7 @@ async def test_non_dynamic_account_records_is_dynamic_false(
     client = MagicMock()
     client.async_get_prices = AsyncMock(return_value=prices)
     client.async_get_monthly_peaks = AsyncMock(return_value=peaks)
+    client.async_get_happy_hour_event = AsyncMock(return_value={})
     _attach_runtime(entry, client)
 
     coordinator = _make_coordinator(hass, entry)
@@ -223,6 +227,7 @@ async def test_is_dynamic_property_reflects_latest_refresh(
     client.async_get_monthly_peaks = AsyncMock(return_value=peaks)
     # First poll: dynamic. Second poll: fixed.
     client.async_get_prices = AsyncMock(side_effect=[{"items": []}, prices])
+    client.async_get_happy_hour_event = AsyncMock(return_value={})
     _attach_runtime(entry, client)
 
     coordinator = _make_coordinator(hass, entry)
@@ -280,6 +285,7 @@ async def test_override_true_wins_over_populated_prices(
     client = MagicMock()
     client.async_get_prices = AsyncMock(return_value=prices)
     client.async_get_monthly_peaks = AsyncMock(return_value=peaks)
+    client.async_get_happy_hour_event = AsyncMock(return_value={})
     sid = _attach_runtime_with_override(entry, client, override=True)
 
     coordinator = _make_coordinator(hass, entry)

--- a/tests/test_coordinator_happy_hour.py
+++ b/tests/test_coordinator_happy_hour.py
@@ -1,0 +1,227 @@
+"""
+Tests for the debug-only happy-hour-event probe in the coordinator.
+
+This module pins the redaction + log-level contract of the probe so we
+catch regressions before they ship in a prerelease. The probe itself
+is debug-only and not meant to merge to ``main``; the tests are kept
+focused so they're cheap to drop when the probe is removed.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.config_entries import ConfigSubentryData
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.engie_be.api import (
+    EngieBeApiClientAuthenticationError,
+    EngieBeApiClientError,
+)
+from custom_components.engie_be.const import (
+    CONF_ACCESS_TOKEN,
+    CONF_BUSINESS_AGREEMENT_NUMBER,
+    CONF_CLIENT_ID,
+    CONF_CONSUMPTION_ADDRESS,
+    CONF_CUSTOMER_NUMBER,
+    CONF_PREMISES_NUMBER,
+    CONF_REFRESH_TOKEN,
+    DEFAULT_CLIENT_ID,
+    DOMAIN,
+    SUBENTRY_TYPE_CUSTOMER_ACCOUNT,
+)
+from custom_components.engie_be.coordinator import EngieBeDataUpdateCoordinator
+from custom_components.engie_be.data import EngieBeData
+
+if TYPE_CHECKING:
+    import pytest
+    from homeassistant.config_entries import ConfigSubentry
+    from homeassistant.core import HomeAssistant
+
+_BAN = "002209795515"
+_EAN = "541448820070414088"
+_CAN = "1504462994"
+
+_NON_EMPTY_PAYLOAD = {
+    "businessAgreementNumber": _BAN,
+    "customerAccountNumber": _CAN,
+    "ean": _EAN,
+    "event": {
+        "startDateTime": "2026-05-19T18:00:00+02:00",
+        "endDateTime": "2026-05-19T20:00:00+02:00",
+        "status": "ACTIVE",
+    },
+}
+
+
+def _build_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Build a v3 MockConfigEntry with one customer-account subentry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=3,
+        title="user@example.com",
+        unique_id="user_example_com",
+        data={
+            CONF_USERNAME: "user@example.com",
+            CONF_PASSWORD: "hunter2",
+            CONF_CLIENT_ID: DEFAULT_CLIENT_ID,
+            CONF_ACCESS_TOKEN: "stored-access",
+            CONF_REFRESH_TOKEN: "stored-refresh",
+        },
+        options={"update_interval": 60},
+        subentries_data=[
+            ConfigSubentryData(
+                subentry_type=SUBENTRY_TYPE_CUSTOMER_ACCOUNT,
+                title="placeholder",
+                unique_id=_CAN,
+                data={
+                    CONF_CUSTOMER_NUMBER: _CAN,
+                    CONF_BUSINESS_AGREEMENT_NUMBER: _BAN,
+                    CONF_PREMISES_NUMBER: "P-0001",
+                    CONF_CONSUMPTION_ADDRESS: "Test 1, 1000 Brussels",
+                },
+            ),
+        ],
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _only_subentry(entry: MockConfigEntry) -> ConfigSubentry:
+    """Return the single customer-account subentry on the test entry."""
+    return next(iter(entry.subentries.values()))
+
+
+def _build_coordinator(
+    hass: HomeAssistant,
+    client: MagicMock,
+) -> EngieBeDataUpdateCoordinator:
+    """Build a coordinator with the runtime stub wired in."""
+    entry = _build_entry(hass)
+    entry.runtime_data = EngieBeData(
+        client=client,
+        epex_coordinator=MagicMock(),
+        subentry_data={},
+        authenticated=True,
+        last_options=dict(entry.options),
+    )
+    return EngieBeDataUpdateCoordinator(
+        hass=hass,
+        config_entry=entry,
+        subentry=_only_subentry(entry),
+    )
+
+
+async def test_happy_hour_probe_logs_non_empty_payload_redacted_at_debug(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    A non-empty response is logged at DEBUG with BAN/EAN/CAN masked.
+
+    Regression guard for the audit blocker: prior to redaction the
+    success path dumped the raw payload at WARNING, leaking the full
+    BAN/EAN/CAN. Pin both the level (DEBUG, not WARNING) and the
+    masking (``_redact_body`` -> last-4 only for partial-mask keys).
+    """
+    client = MagicMock()
+    client.async_get_happy_hour_event = AsyncMock(return_value=_NON_EMPTY_PAYLOAD)
+    coordinator = _build_coordinator(hass, client)
+
+    with caplog.at_level(logging.DEBUG, logger="custom_components.engie_be"):
+        await coordinator._async_log_happy_hour_event(client)
+
+    # Exactly one record from the probe, at DEBUG.
+    probe_records = [
+        r for r in caplog.records if "happy-hour-event response" in r.getMessage()
+    ]
+    assert len(probe_records) == 1
+    record = probe_records[0]
+    assert record.levelno == logging.DEBUG
+
+    message = record.getMessage()
+    # Full identifiers must NOT appear in cleartext.
+    assert _BAN not in message
+    assert _EAN not in message
+    assert _CAN not in message
+    # Partial-mask keys keep the last 4 chars, so the tails do appear.
+    assert "5515" in message  # BAN tail
+    assert "4088" in message  # EAN tail
+    assert "2994" in message  # CAN tail
+    # Non-PII event fields pass through untouched.
+    assert "ACTIVE" in message
+    assert "2026-05-19T18:00:00" in message
+
+    client.async_get_happy_hour_event.assert_awaited_once_with(_BAN)
+
+
+async def test_happy_hour_probe_empty_payload_does_not_warn(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An empty ``{}`` response is logged at DEBUG, never WARNING."""
+    client = MagicMock()
+    client.async_get_happy_hour_event = AsyncMock(return_value={})
+    coordinator = _build_coordinator(hass, client)
+
+    with caplog.at_level(logging.DEBUG, logger="custom_components.engie_be"):
+        await coordinator._async_log_happy_hour_event(client)
+
+    probe_records = [r for r in caplog.records if "happy-hour-event" in r.getMessage()]
+    assert len(probe_records) == 1
+    assert probe_records[0].levelno == logging.DEBUG
+    # No WARNING records from the probe on the happy path.
+    assert not any(
+        r.levelno == logging.WARNING and "happy-hour-event" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+async def test_happy_hour_probe_auth_error_warns_and_swallows(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Auth failure on the probe surfaces a WARNING but does not raise."""
+    client = MagicMock()
+    client.async_get_happy_hour_event = AsyncMock(
+        side_effect=EngieBeApiClientAuthenticationError("token rejected")
+    )
+    coordinator = _build_coordinator(hass, client)
+
+    with caplog.at_level(logging.WARNING, logger="custom_components.engie_be"):
+        # Must not raise -- the probe is best-effort.
+        await coordinator._async_log_happy_hour_event(client)
+
+    warn_records = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+        and "happy-hour-event probe failed (auth)" in r.getMessage()
+    ]
+    assert len(warn_records) == 1
+
+
+async def test_happy_hour_probe_generic_error_warns_and_swallows(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Generic API failure on the probe surfaces a WARNING but does not raise."""
+    client = MagicMock()
+    client.async_get_happy_hour_event = AsyncMock(
+        side_effect=EngieBeApiClientError("upstream 500")
+    )
+    coordinator = _build_coordinator(hass, client)
+
+    with caplog.at_level(logging.WARNING, logger="custom_components.engie_be"):
+        await coordinator._async_log_happy_hour_event(client)
+
+    warn_records = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+        and r.getMessage().startswith("happy-hour-event probe failed:")
+    ]
+    assert len(warn_records) == 1

--- a/tests/test_coordinator_peaks.py
+++ b/tests/test_coordinator_peaks.py
@@ -75,6 +75,7 @@ async def test_update_merges_peaks_into_payload(hass: HomeAssistant) -> None:
     peaks = json.loads(_PEAKS_FIXTURE.read_text(encoding="utf-8"))
 
     client = MagicMock()
+    client.async_get_happy_hour_event = AsyncMock(return_value={})
     client.async_get_prices = AsyncMock(return_value=prices)
     client.async_get_monthly_peaks = AsyncMock(return_value=peaks)
     _attach_runtime(entry, client)
@@ -109,6 +110,7 @@ async def test_update_keeps_last_known_peaks_on_peaks_failure(
     }
 
     client = MagicMock()
+    client.async_get_happy_hour_event = AsyncMock(return_value={})
     client.async_get_prices = AsyncMock(return_value=prices)
     client.async_get_monthly_peaks = AsyncMock(
         side_effect=EngieBeApiClientError("upstream 503"),
@@ -135,6 +137,7 @@ async def test_update_omits_peaks_key_when_no_previous_and_fetch_fails(
     prices = json.loads(_PRICES_FIXTURE.read_text(encoding="utf-8"))
 
     client = MagicMock()
+    client.async_get_happy_hour_event = AsyncMock(return_value={})
     client.async_get_prices = AsyncMock(return_value=prices)
     client.async_get_monthly_peaks = AsyncMock(
         side_effect=EngieBeApiClientError("boom"),
@@ -154,6 +157,7 @@ async def test_peaks_auth_error_triggers_reauth(hass: HomeAssistant) -> None:
     prices = json.loads(_PRICES_FIXTURE.read_text(encoding="utf-8"))
 
     client = MagicMock()
+    client.async_get_happy_hour_event = AsyncMock(return_value={})
     client.async_get_prices = AsyncMock(return_value=prices)
     client.async_get_monthly_peaks = AsyncMock(
         side_effect=EngieBeApiClientAuthenticationError("token rejected"),
@@ -176,6 +180,7 @@ async def test_falls_back_to_previous_month_when_current_has_no_peak(
     empty_current = {"year": 2026, "month": 5, "dailyPeaks": []}
 
     client = MagicMock()
+    client.async_get_happy_hour_event = AsyncMock(return_value={})
     client.async_get_prices = AsyncMock(return_value=prices)
     client.async_get_monthly_peaks = AsyncMock(
         side_effect=[empty_current, previous_peaks],
@@ -213,6 +218,7 @@ async def test_january_falls_back_to_previous_december(
     empty_current = {"year": 2026, "month": 1, "dailyPeaks": []}
 
     client = MagicMock()
+    client.async_get_happy_hour_event = AsyncMock(return_value={})
     client.async_get_prices = AsyncMock(return_value=prices)
     client.async_get_monthly_peaks = AsyncMock(
         side_effect=[empty_current, previous_peaks],
@@ -245,6 +251,7 @@ async def test_fallback_failure_keeps_empty_current_wrapper(
     empty_current = {"year": 2026, "month": 5, "dailyPeaks": []}
 
     client = MagicMock()
+    client.async_get_happy_hour_event = AsyncMock(return_value={})
     client.async_get_prices = AsyncMock(return_value=prices)
     client.async_get_monthly_peaks = AsyncMock(
         side_effect=[empty_current, EngieBeApiClientError("upstream 500")],

--- a/tests/test_coordinator_peaks.py
+++ b/tests/test_coordinator_peaks.py
@@ -118,6 +118,7 @@ async def test_update_merges_peaks_into_payload(hass: HomeAssistant) -> None:
     peaks = json.loads(_PEAKS_FIXTURE.read_text(encoding="utf-8"))
 
     client = MagicMock()
+    client.async_get_happy_hour_event = AsyncMock(return_value={})
     client.async_get_prices = AsyncMock(return_value=prices)
     client.async_get_monthly_peaks = AsyncMock(return_value=peaks)
     _attach_runtime(entry, client)
@@ -152,6 +153,7 @@ async def test_update_keeps_last_known_peaks_on_peaks_failure(
     }
 
     client = MagicMock()
+    client.async_get_happy_hour_event = AsyncMock(return_value={})
     client.async_get_prices = AsyncMock(return_value=prices)
     client.async_get_monthly_peaks = AsyncMock(
         side_effect=EngieBeApiClientError("upstream 503"),
@@ -178,6 +180,7 @@ async def test_update_omits_peaks_key_when_no_previous_and_fetch_fails(
     prices = json.loads(_PRICES_FIXTURE.read_text(encoding="utf-8"))
 
     client = MagicMock()
+    client.async_get_happy_hour_event = AsyncMock(return_value={})
     client.async_get_prices = AsyncMock(return_value=prices)
     client.async_get_monthly_peaks = AsyncMock(
         side_effect=EngieBeApiClientError("boom"),
@@ -197,6 +200,7 @@ async def test_peaks_auth_error_triggers_reauth(hass: HomeAssistant) -> None:
     prices = json.loads(_PRICES_FIXTURE.read_text(encoding="utf-8"))
 
     client = MagicMock()
+    client.async_get_happy_hour_event = AsyncMock(return_value={})
     client.async_get_prices = AsyncMock(return_value=prices)
     client.async_get_monthly_peaks = AsyncMock(
         side_effect=EngieBeApiClientAuthenticationError("token rejected"),
@@ -219,6 +223,7 @@ async def test_falls_back_to_previous_month_when_current_has_no_peak(
     empty_current = {"year": 2026, "month": 5, "dailyPeaks": []}
 
     client = MagicMock()
+    client.async_get_happy_hour_event = AsyncMock(return_value={})
     client.async_get_prices = AsyncMock(return_value=prices)
     client.async_get_monthly_peaks = AsyncMock(
         side_effect=[empty_current, previous_peaks],
@@ -256,6 +261,7 @@ async def test_january_falls_back_to_previous_december(
     empty_current = {"year": 2026, "month": 1, "dailyPeaks": []}
 
     client = MagicMock()
+    client.async_get_happy_hour_event = AsyncMock(return_value={})
     client.async_get_prices = AsyncMock(return_value=prices)
     client.async_get_monthly_peaks = AsyncMock(
         side_effect=[empty_current, previous_peaks],
@@ -288,6 +294,7 @@ async def test_fallback_failure_keeps_empty_current_wrapper(
     empty_current = {"year": 2026, "month": 5, "dailyPeaks": []}
 
     client = MagicMock()
+    client.async_get_happy_hour_event = AsyncMock(return_value={})
     client.async_get_prices = AsyncMock(return_value=prices)
     client.async_get_monthly_peaks = AsyncMock(
         side_effect=[empty_current, EngieBeApiClientError("upstream 500")],

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -77,6 +77,9 @@ def _make_client(
     client.async_get_monthly_peaks = AsyncMock(
         return_value=peaks_return or {"peakOfTheMonth": None, "dailyPeaks": []},
     )
+    # Debug-only probe (debug/happy-hour-event branch); stub so coordinator
+    # doesn't try to await a bare MagicMock.
+    client.async_get_happy_hour_event = AsyncMock(return_value={})
     return client
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -130,6 +130,9 @@ def _make_client(  # noqa: PLR0913 - kwargs-only test helper, one knob per endpo
     # EngieBeEpexCoordinator at first refresh; default to an empty
     # timeSeries so the parser returns an empty payload without raising.
     client.async_get_epex_prices = AsyncMock(return_value={"timeSeries": []})
+    # Debug-only probe (debug/happy-hour-event branch); stub so coordinator
+    # doesn't try to await a bare MagicMock.
+    client.async_get_happy_hour_event = AsyncMock(return_value={})
     return client
 
 


### PR DESCRIPTION
## Purpose

Throwaway debug branch for users to capture the response of the
`happy-hour-event` endpoint and share it with the integration author.

**Not meant to be merged.** Opened as draft so it's auditable but
clearly flagged as do-not-merge.

## Endpoint

```
GET https://api.engie.be/engie/ms/energy-insights/customer/v1/business-agreements/<customer-number>/happy-hour-event
```

## What it does

- Adds `HAPPY_HOUR_BASE_URL` constant.
- Adds `EngieBeApiClient.async_get_happy_hour_event(customer_number)`,
  mirroring the auth/headers pattern of `async_get_monthly_peaks`
  (Bearer token, `x-trace-id`, native user-agent).
- Calls it once per coordinator poll from `_async_update_data`.
- Logs the response as JSON via `json.dumps(..., ensure_ascii=False,
  sort_keys=True)` at `WARNING` level so users see it without enabling
  debug logging.
- Falls back to `%r` if the response is not JSON-serialisable.
- Auth and API errors during the probe are logged at `WARNING` and
  swallowed so the probe never breaks the integration.

## How users use it

1. Add this repo as a HACS custom repository, ref `debug/happy-hour-event`.
2. Reload the integration (or wait one poll cycle).
3. Grep `home-assistant.log` for `happy-hour-event` and share the line.

## Why draft

This branch must not be merged to `main`. It's a one-off probe.