### PR TITLE
fix: heal energy unique_ids stuck in 0.8.0b1 shape on existing installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0b4] - 2026-05-05
+
+> Beta release. Please report issues on
+> [GitHub](https://github.com/DaanVervacke/hass-engie-be/issues).
+
+### Fixed
+- **Energy price sensors that became unavailable after the first 0.8.0
+  beta now recover automatically.** Users who installed 0.8.0b1 and
+  later upgraded to 0.8.0b2 or 0.8.0b3 could see their six gas and
+  electricity offtake/injection price sensors stuck as "unavailable",
+  with new duplicate sensors appearing alongside them. The integration
+  now repairs these sensors automatically the next time it starts. Your
+  original entity IDs, history, and any dashboard or automation
+  references are preserved. No action is required.
+
 ## [0.8.0b3] - 2026-05-05
 
 > Beta release. Please report issues on

--- a/custom_components/engie_be/__init__.py
+++ b/custom_components/engie_be/__init__.py
@@ -731,6 +731,187 @@ async def _async_heal_stale_subentry_links(
         )
 
 
+_B1_ENERGY_UID_DIRECTIONS = (
+    "offtake_excl_vat",
+    "injection_excl_vat",
+    "offtake",
+    "injection",
+)
+
+
+async def _async_heal_b1_energy_unique_ids(
+    hass: HomeAssistant,
+    entry: EngieBeConfigEntry,
+) -> None:
+    """
+    Rewrite 0.8.0b1-shaped energy unique_ids to the canonical v3 shape.
+
+    The 0.8.0b1 release of the v2->v3 migration helper rewrote captar,
+    EPEX, and calendar entities to the subentry-scoped unique_id shape
+    but left energy price entities at the legacy
+    ``{entry_id}_{ean}_{direction}`` shape, because b1's platform also
+    produced that shape so the registry rows still matched. The 0.8.0b3
+    platform produces the canonical
+    ``{entry_id}_{subentry_id}_{ean}_{direction}`` shape, which means
+    direct b1->b3 upgrades end up with six orphan registry rows per
+    customer account (the b1-shape rows that no platform claims) plus a
+    fresh set of canonical entities under brand-new entity_ids. The
+    six orphans show up as "unavailable" in the UI under the user's
+    original entity_ids.
+
+    The fresh installs and v0.7.x->b3 paths do not hit this: a fresh
+    install creates the canonical shape from the start, and a v2->v3
+    migration runs the prefix-sweep helper that rewrites every
+    v2-shaped unique_id (including energy ones) to canonical.
+
+    This pass walks every engie entity in the registry on every setup
+    and, when an entity matches the b1 energy shape, derives its owning
+    subentry from its device's ``(DOMAIN, subentry_id)`` identifier (the
+    b1 device-promote step already moved energy entities onto the
+    subentry-keyed device, so this lookup is reliable). It then
+    rewrites the unique_id to the canonical shape and stamps
+    ``config_subentry_id``. If a canonical sibling already owns the
+    target unique_id (the platform registered fresh entities under new
+    entity_ids on a previous boot), the b1 orphan is removed instead.
+
+    Idempotent: entities already at the canonical shape are skipped.
+    """
+    entry_id = entry.entry_id
+    entry_prefix = f"{entry_id}_"
+    valid_subentry_ids = {
+        sub.subentry_id
+        for sub in entry.subentries.values()
+        if sub.subentry_type == SUBENTRY_TYPE_CUSTOMER_ACCOUNT
+    }
+    if not valid_subentry_ids:
+        return
+
+    # Collect candidates first so the registry mutation does not race
+    # against iteration. ``entity_reg.entities`` is a live mapping.
+    entity_reg = er.async_get(hass)
+    device_reg = dr.async_get(hass)
+    candidates: list[er.RegistryEntry] = []
+    for ent in entity_reg.entities.values():
+        if ent.platform != DOMAIN:
+            continue
+        if ent.config_entry_id != entry_id:
+            continue
+        unique_id = ent.unique_id
+        if not unique_id.startswith(entry_prefix):
+            continue
+        suffix = unique_id[len(entry_prefix) :]
+        # The canonical shape is ``{entry_id}_{subentry_id}_<suffix>``;
+        # b1 energy uids are ``{entry_id}_{ean}_<direction>`` where the
+        # EAN is digits and the direction is one of the four energy
+        # descriptors. The all-digits EAN check rules out canonical
+        # rows because subentry ids are ULIDs (alphanumeric, never
+        # all-digit).
+        if _match_b1_energy_suffix(suffix) is None:
+            continue
+        candidates.append(ent)
+
+    if not candidates:
+        return
+
+    healed = 0
+    dropped = 0
+    skipped = 0
+    for ent in candidates:
+        device = (
+            device_reg.async_get(ent.device_id)
+            if ent.device_id is not None
+            else None
+        )
+        subentry_id = (
+            _subentry_id_from_device(device, valid_subentry_ids)
+            if device
+            else None
+        )
+        if subentry_id is None:
+            LOGGER.warning(
+                "Cannot heal b1-shape energy unique_id %s: no subentry-keyed "
+                "device link found",
+                ent.unique_id,
+            )
+            skipped += 1
+            continue
+
+        suffix = ent.unique_id[len(entry_prefix) :]
+        new_unique_id = f"{entry_id}_{subentry_id}_{suffix}"
+        existing = entity_reg.async_get_entity_id(
+            ent.domain, DOMAIN, new_unique_id
+        )
+        if existing is not None and existing != ent.entity_id:
+            entity_reg.async_remove(ent.entity_id)
+            dropped += 1
+            LOGGER.info(
+                "Removed b1-shape energy entity %s; canonical sibling %s "
+                "already owns unique_id %s",
+                ent.entity_id,
+                existing,
+                new_unique_id,
+            )
+            continue
+
+        entity_reg.async_update_entity(
+            ent.entity_id,
+            new_unique_id=new_unique_id,
+            config_subentry_id=subentry_id,
+        )
+        healed += 1
+        LOGGER.info(
+            "Healed b1-shape energy unique_id %s -> %s (subentry %s)",
+            ent.unique_id,
+            new_unique_id,
+            subentry_id,
+        )
+
+    if healed or dropped or skipped:
+        LOGGER.info(
+            "b1 energy unique_id heal: healed=%d dropped=%d skipped=%d",
+            healed,
+            dropped,
+            skipped,
+        )
+
+
+def _match_b1_energy_suffix(suffix: str) -> tuple[str, str] | None:
+    """
+    Return ``(ean, direction)`` if ``suffix`` matches a b1 energy uid.
+
+    A b1 energy uid suffix is ``<ean>_<direction>`` where ``ean`` is all
+    digits and ``direction`` is one of the four energy descriptors. The
+    direction list is ordered longest-first so ``offtake_excl_vat`` is
+    matched before ``offtake``.
+    """
+    for direction in _B1_ENERGY_UID_DIRECTIONS:
+        marker = f"_{direction}"
+        if not suffix.endswith(marker):
+            continue
+        ean = suffix[: -len(marker)]
+        if ean and ean.isdigit():
+            return ean, direction
+    return None
+
+
+def _subentry_id_from_device(
+    device: dr.DeviceEntry,
+    valid_subentry_ids: set[str],
+) -> str | None:
+    """
+    Return the ``(DOMAIN, subentry_id)`` identifier value, or ``None``.
+
+    ``valid_subentry_ids`` is the set of ``ConfigSubentry.subentry_id``
+    values currently attached to the parent entry, used to discriminate
+    customer-account devices (identifier value is the ULID subentry id)
+    from the login device (identifier value is ``login_<entry_id>``).
+    """
+    for domain, value in device.identifiers:
+        if domain == DOMAIN and value in valid_subentry_ids:
+            return value
+    return None
+
+
 async def _async_migrate_legacy_subentry_unique_ids(
     hass: HomeAssistant,
     entry: EngieBeConfigEntry,
@@ -984,6 +1165,12 @@ async def async_setup_entry(
     # rendered as two duplicate device rows. Idempotent and a no-op
     # on healthy installs.
     await _async_heal_stale_subentry_links(hass, entry)
+
+    # Heal energy price entities whose unique_ids were left at the
+    # 0.8.0b1 shape by direct b1->b3 upgrades. Idempotent and a no-op
+    # on healthy installs (b2->b3 and v0.7.x->b3 paths already produce
+    # the canonical shape).
+    await _async_heal_b1_energy_unique_ids(hass, entry)
 
     # One-shot migration of legacy BAN-shaped subentry unique_ids to
     # canonical CAN values. Idempotent and tolerant of relations API

--- a/custom_components/engie_be/manifest.json
+++ b/custom_components/engie_be/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.engie_be"
   ],
   "quality_scale": "bronze",
-  "version": "0.8.0b3"
+  "version": "0.8.0b4"
 }

--- a/tests/test_heal_b1_energy_unique_ids.py
+++ b/tests/test_heal_b1_energy_unique_ids.py
@@ -1,0 +1,388 @@
+"""Tests for the b1->b3 energy unique_id heal pass."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.config_entries import ConfigSubentryData
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.engie_be import _async_heal_b1_energy_unique_ids
+from custom_components.engie_be.const import (
+    CONF_ACCESS_TOKEN,
+    CONF_BUSINESS_AGREEMENT_NUMBER,
+    CONF_CLIENT_ID,
+    CONF_CONSUMPTION_ADDRESS,
+    CONF_CUSTOMER_NUMBER,
+    CONF_PREMISES_NUMBER,
+    CONF_REFRESH_TOKEN,
+    DEFAULT_CLIENT_ID,
+    DOMAIN,
+    SUBENTRY_TYPE_CUSTOMER_ACCOUNT,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+def _build_entry_with_subentries(
+    hass: HomeAssistant,
+    *,
+    customer_numbers: tuple[str, ...] = ("1500000001",),
+) -> MockConfigEntry:
+    """Build a v3 MockConfigEntry with one or more customer-account subentries."""
+    subentries: list[ConfigSubentryData] = [
+        ConfigSubentryData(
+            subentry_type=SUBENTRY_TYPE_CUSTOMER_ACCOUNT,
+            title=f"Account {cn}",
+            unique_id=cn,
+            data={
+                CONF_CUSTOMER_NUMBER: cn,
+                CONF_BUSINESS_AGREEMENT_NUMBER: f"B-{cn}",
+                CONF_PREMISES_NUMBER: f"P-{cn}",
+                CONF_CONSUMPTION_ADDRESS: f"Addr {cn}",
+            },
+        )
+        for cn in customer_numbers
+    ]
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=3,
+        title="user@example.com",
+        unique_id="user_example_com",
+        data={
+            CONF_USERNAME: "user@example.com",
+            CONF_PASSWORD: "hunter2",
+            CONF_CLIENT_ID: DEFAULT_CLIENT_ID,
+            CONF_ACCESS_TOKEN: "stored-access",
+            CONF_REFRESH_TOKEN: "stored-refresh",
+        },
+        options={"update_interval": 60},
+        subentries_data=subentries,
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _create_subentry_device(
+    hass: HomeAssistant,
+    entry: MockConfigEntry,
+    subentry_id: str,
+) -> dr.DeviceEntry:
+    """Create the customer-account device that owns energy entities."""
+    device_reg = dr.async_get(hass)
+    return device_reg.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        config_subentry_id=subentry_id,
+        identifiers={(DOMAIN, subentry_id)},
+        manufacturer="ENGIE Belgium",
+        name=f"Premises {subentry_id}",
+    )
+
+
+def _create_login_device(
+    hass: HomeAssistant,
+    entry: MockConfigEntry,
+) -> dr.DeviceEntry:
+    """Create the login-scoped device used by the auth binary sensor."""
+    device_reg = dr.async_get(hass)
+    return device_reg.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, f"login_{entry.entry_id}")},
+        manufacturer="ENGIE Belgium",
+        name="Account",
+    )
+
+
+def _seed_b1_energy_entity(  # noqa: PLR0913 - test seeder, all kwargs are intent-revealing
+    hass: HomeAssistant,
+    entry: MockConfigEntry,
+    *,
+    device_id: str,
+    ean: str,
+    direction: str,
+    suggested_object_id: str | None = None,
+) -> str:
+    """
+    Seed a single b1-shape energy entity in the registry.
+
+    Returns the resulting ``entity_id`` so callers can assert it survives
+    the rewrite (the contract is that user-facing entity_ids must not
+    change when only the unique_id is rewritten).
+    """
+    entity_reg = er.async_get(hass)
+    old_uid = f"{entry.entry_id}_{ean}_{direction}"
+    ent = entity_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        old_uid,
+        suggested_object_id=suggested_object_id or f"engie_be_{ean}_{direction}",
+        config_entry=entry,
+        device_id=device_id,
+        # Deliberately leave config_subentry_id unset to mirror the
+        # b1 bug shape exactly.
+    )
+    return ent.entity_id
+
+
+async def test_heal_rewrites_b1_energy_uids_to_canonical_shape(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """A b1-shape energy uid must be rewritten and stamped with subentry_id."""
+    entry = _build_entry_with_subentries(hass)
+    subentry = next(iter(entry.subentries.values()))
+    device = _create_subentry_device(hass, entry, subentry.subentry_id)
+
+    ean = "541448820000000001"
+    seeded_entity_ids: dict[tuple[str, str], str] = {}
+    for direction in ("offtake", "offtake_excl_vat", "injection", "injection_excl_vat"):
+        seeded_entity_ids[(ean, direction)] = _seed_b1_energy_entity(
+            hass,
+            entry,
+            device_id=device.id,
+            ean=ean,
+            direction=direction,
+        )
+
+    await _async_heal_b1_energy_unique_ids(hass, entry)
+
+    entity_reg = er.async_get(hass)
+    for (e, direction), entity_id in seeded_entity_ids.items():
+        ent = entity_reg.async_get(entity_id)
+        assert ent is not None, f"entity {entity_id} disappeared"
+        expected_uid = f"{entry.entry_id}_{subentry.subentry_id}_{e}_{direction}"
+        assert ent.unique_id == expected_uid, (
+            f"unique_id not rewritten: got {ent.unique_id}, want {expected_uid}"
+        )
+        assert ent.config_subentry_id == subentry.subentry_id
+
+
+async def test_heal_drops_b1_orphan_when_canonical_sibling_exists(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """
+    Remove the b1 orphan when a canonical-shape sibling already exists.
+
+    This mirrors the boot-after-failed-heal scenario: a previous b3 boot
+    registered fresh canonical entities under new entity_ids while the
+    b1-shape rows lingered as unavailable orphans.
+    """
+    entry = _build_entry_with_subentries(hass)
+    subentry = next(iter(entry.subentries.values()))
+    device = _create_subentry_device(hass, entry, subentry.subentry_id)
+
+    ean = "541448820000000001"
+    direction = "offtake"
+    canonical_uid = f"{entry.entry_id}_{subentry.subentry_id}_{ean}_{direction}"
+
+    # b1 orphan: no config_subentry_id, b1-shape uid, original entity_id.
+    b1_entity_id = _seed_b1_energy_entity(
+        hass,
+        entry,
+        device_id=device.id,
+        ean=ean,
+        direction=direction,
+        suggested_object_id="engie_be_offtake",
+    )
+    # Canonical sibling registered later by the b3 platform.
+    entity_reg = er.async_get(hass)
+    canonical = entity_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        canonical_uid,
+        suggested_object_id="lindestraat_offtake_price",
+        config_entry=entry,
+        config_subentry_id=subentry.subentry_id,
+        device_id=device.id,
+    )
+
+    await _async_heal_b1_energy_unique_ids(hass, entry)
+
+    assert entity_reg.async_get(b1_entity_id) is None, (
+        "b1 orphan should be removed when canonical sibling exists"
+    )
+    survivor = entity_reg.async_get(canonical.entity_id)
+    assert survivor is not None
+    assert survivor.unique_id == canonical_uid
+
+
+async def test_heal_is_noop_on_canonical_install(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """A clean v3 install must be untouched by the heal pass."""
+    entry = _build_entry_with_subentries(hass)
+    subentry = next(iter(entry.subentries.values()))
+    device = _create_subentry_device(hass, entry, subentry.subentry_id)
+
+    entity_reg = er.async_get(hass)
+    canonical_uid = (
+        f"{entry.entry_id}_{subentry.subentry_id}_541448820000000001_offtake"
+    )
+    ent = entity_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        canonical_uid,
+        suggested_object_id="engie_be_offtake",
+        config_entry=entry,
+        config_subentry_id=subentry.subentry_id,
+        device_id=device.id,
+    )
+    snapshot: dict[str, Any] = {
+        "unique_id": ent.unique_id,
+        "config_subentry_id": ent.config_subentry_id,
+        "entity_id": ent.entity_id,
+    }
+
+    await _async_heal_b1_energy_unique_ids(hass, entry)
+
+    after = entity_reg.async_get(ent.entity_id)
+    assert after is not None
+    assert after.unique_id == snapshot["unique_id"]
+    assert after.config_subentry_id == snapshot["config_subentry_id"]
+
+
+async def test_heal_is_idempotent_on_repeat_invocation(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """Two heal passes back-to-back must not change state after the first."""
+    entry = _build_entry_with_subentries(hass)
+    subentry = next(iter(entry.subentries.values()))
+    device = _create_subentry_device(hass, entry, subentry.subentry_id)
+
+    entity_id = _seed_b1_energy_entity(
+        hass,
+        entry,
+        device_id=device.id,
+        ean="541448820000000001",
+        direction="offtake_excl_vat",
+    )
+
+    await _async_heal_b1_energy_unique_ids(hass, entry)
+    entity_reg = er.async_get(hass)
+    first = entity_reg.async_get(entity_id)
+    assert first is not None
+    first_state = (first.unique_id, first.config_subentry_id)
+
+    await _async_heal_b1_energy_unique_ids(hass, entry)
+    second = entity_reg.async_get(entity_id)
+    assert second is not None
+    assert (second.unique_id, second.config_subentry_id) == first_state
+
+
+async def test_heal_skips_entity_without_subentry_keyed_device(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """
+    Skip entities whose device is not a customer-account device.
+
+    An energy entity attached to the login device (or no device) cannot be
+    healed because there is no subentry to attribute it to. The helper
+    must log a warning and leave the row untouched.
+    """
+    entry = _build_entry_with_subentries(hass)
+    login_device = _create_login_device(hass, entry)
+
+    entity_id = _seed_b1_energy_entity(
+        hass,
+        entry,
+        device_id=login_device.id,
+        ean="541448820000000001",
+        direction="offtake",
+    )
+
+    await _async_heal_b1_energy_unique_ids(hass, entry)
+
+    entity_reg = er.async_get(hass)
+    ent = entity_reg.async_get(entity_id)
+    assert ent is not None, "untouched entity must survive"
+    # Unique id must still be the b1 shape because nothing was rewritten.
+    assert ent.unique_id == f"{entry.entry_id}_541448820000000001_offtake"
+    assert ent.config_subentry_id is None
+
+
+async def test_heal_attributes_uids_to_correct_subentry_in_multi_account(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """
+    Route each b1 uid to the correct subentry in a multi-account install.
+
+    With two customer-account subentries each owning their own EAN, the
+    heal must route each b1-shape uid to the subentry whose device the
+    entity is attached to (not the first or last subentry by iteration).
+    """
+    entry = _build_entry_with_subentries(
+        hass,
+        customer_numbers=("1500000001", "1500000002"),
+    )
+    sub_a, sub_b = entry.subentries.values()
+    device_a = _create_subentry_device(hass, entry, sub_a.subentry_id)
+    device_b = _create_subentry_device(hass, entry, sub_b.subentry_id)
+
+    ean_a = "541448820000000001"
+    ean_b = "541448820000000002"
+    entity_a = _seed_b1_energy_entity(
+        hass,
+        entry,
+        device_id=device_a.id,
+        ean=ean_a,
+        direction="offtake",
+        suggested_object_id="engie_be_a_offtake",
+    )
+    entity_b = _seed_b1_energy_entity(
+        hass,
+        entry,
+        device_id=device_b.id,
+        ean=ean_b,
+        direction="offtake",
+        suggested_object_id="engie_be_b_offtake",
+    )
+
+    await _async_heal_b1_energy_unique_ids(hass, entry)
+
+    entity_reg = er.async_get(hass)
+    a = entity_reg.async_get(entity_a)
+    b = entity_reg.async_get(entity_b)
+    assert a is not None
+    assert b is not None
+    assert a.unique_id == f"{entry.entry_id}_{sub_a.subentry_id}_{ean_a}_offtake"
+    assert a.config_subentry_id == sub_a.subentry_id
+    assert b.unique_id == f"{entry.entry_id}_{sub_b.subentry_id}_{ean_b}_offtake"
+    assert b.config_subentry_id == sub_b.subentry_id
+
+
+async def test_heal_returns_early_when_no_customer_subentries(
+    hass: HomeAssistant,
+    enable_custom_integrations: object,  # noqa: ARG001
+) -> None:
+    """An entry with zero customer subentries is a no-op."""
+    entry = _build_entry_with_subentries(hass, customer_numbers=())
+    # Even if we seed something b1-shaped, the absence of subentries
+    # short-circuits the heal so nothing is rewritten.
+    fake_device = dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, f"login_{entry.entry_id}")},
+        name="Login",
+    )
+    entity_id = _seed_b1_energy_entity(
+        hass,
+        entry,
+        device_id=fake_device.id,
+        ean="541448820000000001",
+        direction="offtake",
+    )
+
+    await _async_heal_b1_energy_unique_ids(hass, entry)
+
+    entity_reg = er.async_get(hass)
+    ent = entity_reg.async_get(entity_id)
+    assert ent is not None
+    assert ent.unique_id == f"{entry.entry_id}_541448820000000001_offtake"


### PR DESCRIPTION
## Summary
- Adds a setup-time heal pass that repairs the six gas/electricity offtake/injection price sensors left unavailable for users who installed `0.8.0b1` and later upgraded to `0.8.0b2` or `0.8.0b3`.
- Bumps version to `0.8.0b4`.

## Root cause
`0.8.0b1`'s `_migrate_entity_unique_ids` used a fixed list of suffixes that excluded the energy-price descriptors (`offtake`, `injection`, `offtake_excl_vat`, `injection_excl_vat`). Those entities were left at the v2 unique_id shape `{entry_id}_{ean}_{direction}` while their device was promoted to the customer-account device. Because b1 already bumped the entry's storage version to 3, `async_migrate_entry` never re-runs for these installs, so the v2 → v3 unique_id sweep added in b2 (`83ffd7d`) was never applied to them. Result: the stuck rows show as unavailable, and a fresh canonical sibling entity gets created on the next boot.

## Fix
New `_async_heal_b1_energy_unique_ids` runs unconditionally on `async_setup_entry` (after the stale-subentry-link heal, before the legacy unique_id migration). For each entity:

1. Match unique_id against the b1 shape `{entry_id}_<digits>_<direction>`.
2. Look up the entity's device, then resolve the subentry by finding the `(DOMAIN, value)` identifier whose value is in the entry's customer-subentry id set. This handles multi-subentry installs correctly (a naive prefix sweep would cross-attribute uids).
3. If a canonical sibling already owns the v3 unique_id, drop the b1 orphan via `async_remove`.
4. Otherwise, rewrite the unique_id to v3 shape `{entry_id}_{subentry_id}_{ean}_{direction}` and assign `config_subentry_id`. The existing entity_id is preserved, so dashboards, automations, and history survive.
5. Skip with a warning if the device link is missing or doesn't point at a customer subentry (defensive).

## Tests
Adds `tests/test_heal_b1_energy_unique_ids.py` with 7 cases:

- rewrite path
- drop b1 orphan when canonical sibling exists
- no-op on canonical install
- idempotency on repeat invocation
- skip + warn when device link is missing
- multi-subentry attribution correctness (2 accounts, 2 EANs, no cross-talk)
- early-return when entry has zero customer subentries

Full suite: 253/253 pass. Ruff clean.

## Manual validation
Verified end-to-end in a devcontainer against synthesized broken registry states for both branches:

- Rewrite path: 6 b1 orphans, no canonicals → 6 healed, 0 dropped, original entity_ids preserved.
- Drop path: 6 b1 orphans + 6 canonicals → 0 healed, 6 dropped, canonicals retained with original entity_ids.

Registry persisted correctly to disk after clean shutdown in both runs.