### PR TITLE
chore: apply ruff format to heal helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0b5] - 2026-05-05
+
+> Beta release. Please report issues on
+> [GitHub](https://github.com/DaanVervacke/hass-engie-be/issues).
+
+### Changed
+- Internal: code formatting fix; no functional change.
+
 ## [0.8.0b4] - 2026-05-05
 
 > Beta release. Please report issues on

--- a/custom_components/engie_be/__init__.py
+++ b/custom_components/engie_be/__init__.py
@@ -818,14 +818,10 @@ async def _async_heal_b1_energy_unique_ids(
     skipped = 0
     for ent in candidates:
         device = (
-            device_reg.async_get(ent.device_id)
-            if ent.device_id is not None
-            else None
+            device_reg.async_get(ent.device_id) if ent.device_id is not None else None
         )
         subentry_id = (
-            _subentry_id_from_device(device, valid_subentry_ids)
-            if device
-            else None
+            _subentry_id_from_device(device, valid_subentry_ids) if device else None
         )
         if subentry_id is None:
             LOGGER.warning(
@@ -838,9 +834,7 @@ async def _async_heal_b1_energy_unique_ids(
 
         suffix = ent.unique_id[len(entry_prefix) :]
         new_unique_id = f"{entry_id}_{subentry_id}_{suffix}"
-        existing = entity_reg.async_get_entity_id(
-            ent.domain, DOMAIN, new_unique_id
-        )
+        existing = entity_reg.async_get_entity_id(ent.domain, DOMAIN, new_unique_id)
         if existing is not None and existing != ent.entity_id:
             entity_reg.async_remove(ent.entity_id)
             dropped += 1

--- a/custom_components/engie_be/manifest.json
+++ b/custom_components/engie_be/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.engie_be"
   ],
   "quality_scale": "bronze",
-  "version": "0.8.0b4"
+  "version": "0.8.0b5"
 }


### PR DESCRIPTION
## Summary
- CI on #69 ran \`ruff format --check .\` and failed: \`custom_components/engie_be/__init__.py\` needed reformatting.
- Fix is three trivial whitespace collapses in \`_async_heal_b1_energy_unique_ids\` where ternaries and a function call were over-wrapped but fit within 88 cols on one line.
- Bumps to \`0.8.0b5\`.

## Diff
Format-only. No functional change. Behavior identical to \`0.8.0b4\`.

## Tests
253/253 pass. Ruff format and check both clean locally.

## Process note
Going forward I will run \`scripts/lint\` (which does \`ruff format\` then \`ruff check --fix\`) before commit instead of \`ruff check\` alone.