### PR TITLE
fix: skip token-storage rewrite when unchanged and add trace id to energy-contracts (0.8.0b7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0b7] - 2026-05-05
+
+> Beta release. Please report issues on
+> [GitHub](https://github.com/DaanVervacke/hass-engie-be/issues).
+
+### Changed
+- **Reduced background writes to Home Assistant's config storage.**
+  The integration previously rewrote its stored ENGIE login tokens
+  on every refresh cycle, even when the tokens had not actually
+  changed. It now writes only when at least one token is different,
+  matching the pattern recommended for OAuth-based integrations.
+  This avoids needless churn on the configuration storage file.
+
+### Fixed
+- **Improved server-side traceability for the dynamic-tariff
+  detection call.** The request the integration uses to identify
+  dynamic-electricity accounts now includes the same per-request
+  trace identifier as every other ENGIE API call, so server-side
+  logs can correlate it with the rest of a refresh cycle. There is
+  no user-visible change.
+
 ## [0.8.0b6] - 2026-05-05
 
 > Beta release. Please report issues on

--- a/custom_components/engie_be/__init__.py
+++ b/custom_components/engie_be/__init__.py
@@ -1346,7 +1346,20 @@ def _persist_tokens(
     access_token: str,
     refresh_token: str,
 ) -> None:
-    """Persist refreshed tokens to the config entry data."""
+    """
+    Persist refreshed tokens to the config entry data.
+
+    Skips the write when both tokens already match what is stored, so
+    routine coordinator refreshes that hand back the same access token
+    do not dirty ``core.config_entries`` storage. ENGIE rotates the
+    refresh token on every successful exchange, so in practice this
+    short-circuit only fires when the OAuth helper returns a cached
+    token (e.g. when the previous access token is still valid).
+    """
+    current_access = entry.data.get(CONF_ACCESS_TOKEN)
+    current_refresh = entry.data.get(CONF_REFRESH_TOKEN)
+    if current_access == access_token and current_refresh == refresh_token:
+        return
     updated_data = {**entry.data}
     updated_data[CONF_ACCESS_TOKEN] = access_token
     updated_data[CONF_REFRESH_TOKEN] = refresh_token

--- a/custom_components/engie_be/api.py
+++ b/custom_components/engie_be/api.py
@@ -326,6 +326,7 @@ class EngieBeApiClient:
             "User-Agent": USER_AGENT_BROWSER,
             "Accept": "application/json, application/problem+json",
             "authorization": f"Bearer {self.access_token}",
+            "x-trace-id": str(uuid.uuid4()),
         }
         return await self._api_wrapper(
             session=self._session,

--- a/custom_components/engie_be/manifest.json
+++ b/custom_components/engie_be/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.engie_be"
   ],
   "quality_scale": "bronze",
-  "version": "0.8.0b6"
+  "version": "0.8.0b7"
 }


### PR DESCRIPTION
## Summary

Two findings from the HA-docs audit of `release/v0.8.0` at b6.

### C1: stop dirtying `core.config_entries` on every refresh

`_persist_tokens` previously rewrote `entry.data` unconditionally on every coordinator refresh, calling `hass.config_entries.async_update_entry` even when ENGIE returned the same tokens. This dirtied the configuration storage file on every poll cycle (every 15 minutes per entry).

The function now compares both the access token and refresh token against `entry.data` and short-circuits the write when neither has rotated. ENGIE rotates the refresh token on every successful exchange, so in practice the no-op path fires only when the OAuth helper hands back a still-valid cached access token, but the savings are real over the lifetime of the entry.

This matches the pattern used by HA's own OAuth2 helper, which only persists token dicts when they actually change.

### C2: thread `x-trace-id` through the energy-contracts call

`async_get_energy_contracts` was the only authenticated GET in the API client that did not send a per-request `x-trace-id`. Every other endpoint (`async_get_consumption`, `async_get_business_agreements`, `async_get_customer_account_relations`, etc.) already included one.

Adding the header makes the dynamic-tariff detection call correlatable with the rest of a refresh cycle on the server side, which matters when triaging incidents on the dynamic-detection path that was introduced in 0.8.0b6.

## Why now

Both findings surfaced during a read-only audit of the entire `custom_components/engie_be/` tree against current Home Assistant developer documentation. Both are low-risk and self-contained, so they are landing as 0.8.0b7 ahead of the larger High and Medium tier follow-ups.

## Changes

- `custom_components/engie_be/__init__.py`: short-circuit `_persist_tokens` when both tokens already match storage, and document the new behavior.
- `custom_components/engie_be/api.py`: add `"x-trace-id": str(uuid.uuid4())` to the energy-contracts request headers.
- `custom_components/engie_be/manifest.json`: bump to `0.8.0b7`.
- `CHANGELOG.md`: add `[0.8.0b7]` entry under Changed and Fixed.

## Test plan

- `scripts/lint` clean.
- Live upgrade from 0.8.0b6 to 0.8.0b7 on the prod HA instance after release tag is published.
- Confirm coordinator refreshes no longer touch `.storage/core.config_entries` mtime when ENGIE returns identical tokens (rare in practice; see commit message).
- Confirm new `x-trace-id` appears in outbound headers for the energy-contracts call (requires either debug capture or trusting that other endpoints with the same wrapper already do this).