### PR TITLE
chore: mark authentication sensor as diagnostic entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **Authentication sensor moved to diagnostics.** The
+  **Authentication** binary sensor is now categorised as a diagnostic
+  entity, so it no longer appears on default dashboards (Overview,
+  Energy). It remains visible on the integration's device page and
+  continues to work in automations and on any custom dashboard that
+  references it directly.
+
 ## [0.8.0] - 2026-05-05
 
 > [!IMPORTANT]

--- a/custom_components/engie_be/binary_sensor.py
+++ b/custom_components/engie_be/binary_sensor.py
@@ -9,6 +9,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
+from homeassistant.const import EntityCategory
 from homeassistant.util import dt as dt_util
 
 from .const import LOGGER, SUBENTRY_TYPE_CUSTOMER_ACCOUNT
@@ -30,6 +31,7 @@ AUTHENTICATION_SENSOR_DESCRIPTION = BinarySensorEntityDescription(
     key="authentication",
     translation_key="authentication",
     device_class=BinarySensorDeviceClass.CONNECTIVITY,
+    entity_category=EntityCategory.DIAGNOSTIC,
     icon="mdi:shield-check",
 )
 

--- a/tests/test_binary_sensor_epex.py
+++ b/tests/test_binary_sensor_epex.py
@@ -6,6 +6,8 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 from zoneinfo import ZoneInfo
 
+from homeassistant.const import EntityCategory
+
 from custom_components.engie_be.binary_sensor import (
     EPEX_NEGATIVE_SENSOR_DESCRIPTION,
     EngieBeAuthSensor,
@@ -299,6 +301,8 @@ async def test_setup_entry_omits_negative_sensor_for_non_dynamic_account() -> No
     # Only the per-entry auth sensor; no EPEX negative entity.
     assert len(added) == 1
     assert isinstance(added[0], EngieBeAuthSensor)
+    # Auth sensor is a diagnostic entity so it stays out of default dashboards.
+    assert added[0].entity_category is EntityCategory.DIAGNOSTIC
 
 
 async def test_setup_entry_adds_negative_sensor_for_dynamic_account() -> None:


### PR DESCRIPTION
## Summary
- Set `entity_category=EntityCategory.DIAGNOSTIC` on the `Authentication` binary sensor description so it no longer surfaces in default UI dashboards (Overview, Energy).
- The sensor still appears on the integration's device page and remains usable in automations and on any custom dashboard that references it directly.
- Closes the Silver-tier `entity-category` gap identified in the audit (M2).

## Behavioural impact
Existing users will see the **Authentication** sensor disappear from default dashboard surfaces on the next reload. No automation that references the entity by ID is affected.

## Verification
- `ruff check` + `ruff format --check` on changed files: clean.
- Test assertion added in `tests/test_binary_sensor_epex.py` covering the new entity category.

Run locally:
\`\`\`
scripts/setup
pytest tests/test_binary_sensor_epex.py
\`\`\`