### PR TITLE
chore: release 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.1] - 2026-05-06
 
 ### Changed
 - **Authentication sensor moved to diagnostics.** The
@@ -298,7 +298,8 @@ No user-visible changes.
 [#59]: https://github.com/DaanVervacke/hass-engie-be/pull/59
 [#61]: https://github.com/DaanVervacke/hass-engie-be/pull/61
 
-[Unreleased]: https://github.com/DaanVervacke/hass-engie-be/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/DaanVervacke/hass-engie-be/compare/v0.8.1...HEAD
+[0.8.1]: https://github.com/DaanVervacke/hass-engie-be/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/DaanVervacke/hass-engie-be/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/DaanVervacke/hass-engie-be/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/DaanVervacke/hass-engie-be/compare/v0.6.1...v0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **Authentication sensor moved to diagnostics.** The
+  **Authentication** binary sensor is now categorised as a diagnostic
+  entity, so it no longer appears on default dashboards (Overview,
+  Energy). It remains visible on the integration's device page and
+  continues to work in automations and on any custom dashboard that
+  references it directly.
+
 ## [0.8.0] - 2026-05-05
 
 > [!IMPORTANT]

--- a/custom_components/engie_be/binary_sensor.py
+++ b/custom_components/engie_be/binary_sensor.py
@@ -9,6 +9,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
+from homeassistant.const import EntityCategory
 from homeassistant.util import dt as dt_util
 
 from .const import LOGGER, SUBENTRY_TYPE_CUSTOMER_ACCOUNT
@@ -30,6 +31,7 @@ AUTHENTICATION_SENSOR_DESCRIPTION = BinarySensorEntityDescription(
     key="authentication",
     translation_key="authentication",
     device_class=BinarySensorDeviceClass.CONNECTIVITY,
+    entity_category=EntityCategory.DIAGNOSTIC,
     icon="mdi:shield-check",
 )
 

--- a/custom_components/engie_be/manifest.json
+++ b/custom_components/engie_be/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.engie_be"
   ],
   "quality_scale": "bronze",
-  "version": "0.8.0"
+  "version": "0.8.1"
 }

--- a/tests/test_binary_sensor_epex.py
+++ b/tests/test_binary_sensor_epex.py
@@ -6,6 +6,8 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 from zoneinfo import ZoneInfo
 
+from homeassistant.const import EntityCategory
+
 from custom_components.engie_be.binary_sensor import (
     EPEX_NEGATIVE_SENSOR_DESCRIPTION,
     EngieBeAuthSensor,
@@ -299,6 +301,8 @@ async def test_setup_entry_omits_negative_sensor_for_non_dynamic_account() -> No
     # Only the per-entry auth sensor; no EPEX negative entity.
     assert len(added) == 1
     assert isinstance(added[0], EngieBeAuthSensor)
+    # Auth sensor is a diagnostic entity so it stays out of default dashboards.
+    assert added[0].entity_category is EntityCategory.DIAGNOSTIC
 
 
 async def test_setup_entry_adds_negative_sensor_for_dynamic_account() -> None:


### PR DESCRIPTION
## Summary
- Cuts the **0.8.1** release.
- Bumps \`manifest.json\` version \`0.8.0\` → \`0.8.1\`.
- Promotes the \`[Unreleased]\` CHANGELOG section to \`[0.8.1] - 2026-05-06\` and updates compare links.

## Contents of 0.8.1
- **Authentication sensor moved to diagnostics** (#73 / chore/auth-sensor-diagnostic-category) — closes Silver \`entity-category\` audit gap.

## Merge order
**Merge #73 first**, then this PR. After merge, tag \`v0.8.1\` on \`main\`.

## Verification
- Diff is intentionally minimal: CHANGELOG section rename + manifest version bump only, matching the pattern of #68 (v0.8.0 release).