### PR TITLE
chore(ci): enforce minimum test coverage of 85%

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,4 +30,4 @@ jobs:
           python -m pip install -r requirements.txt
 
       - name: Run tests
-        run: python -m pytest tests/ -v --tb=short --cov=custom_components.engie_be --cov-report=term-missing
+        run: python -m pytest tests/ -v --tb=short --cov=custom_components.engie_be --cov-report=term-missing --cov-fail-under=85

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Chore
+- **CI now enforces a minimum test coverage of 85%.** The test
+  workflow fails when overall coverage of `custom_components.engie_be`
+  drops below this floor, protecting against regressions that quietly
+  remove tested code paths. Internal change only, with no
+  user-visible impact.
+
 ## [0.8.1] - 2026-05-06
 
 ### Changed


### PR DESCRIPTION
## Summary
Add `--cov-fail-under=85` to the pytest invocation in `.github/workflows/test.yml`. Coverage was already being measured and reported, but no minimum was enforced. A PR that silently dropped covered code paths would have passed CI.

## Baseline
Measured from the last successful `test.yml` run on `main` (commit 462f020, the v0.8.1 merge):

```
TOTAL    1903    293    85%
```

Floor set to **85%** (tight strategy, matching current baseline). Per pytest-cov rounding, a drop to 84.5% still reports `85%` and passes; a drop to 84.4% reports `84%` and fails.

## What this catches
- Refactors that delete covered code without adjusting tests.
- New code paths added without test coverage that pull the average down enough to round to <85%.

## What this doesn't catch
- Slow erosion within the same rounding bucket.
- Per-file coverage drops (this is a project-wide gate).

## Closes
Audit finding L4 (coverage gate not enforced).

## No version bump
CI-only change. No runtime behaviour, no `manifest.json` bump, no release branch. Will ride into the next user-visible release. Logged under `[Unreleased] / Chore` in CHANGELOG.

## Future tuning
Raise the floor by editing the `--cov-fail-under` value when sustained coverage gains land. No automation for this.