### PR TITLE
feat: add EPEX next-hour wholesale price sensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,11 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
-### Chore
-- **CI now enforces a minimum test coverage of 85%.** The test
-  workflow fails when overall coverage of `custom_components.engie_be`
-  drops below this floor, protecting against regressions that quietly
-  remove tested code paths. Internal change only, with no
-  user-visible impact.
+### Added
+- **New `EPEX next hour price` sensor** for dynamic-tariff
+  electricity accounts. Shows the wholesale electricity price one
+  hour from now, so you can run appliances when the upcoming hour
+  is cheap.
 
 ## [0.8.1] - 2026-05-06
 

--- a/README.md
+++ b/README.md
@@ -103,17 +103,18 @@ event description.
 
 ### Dynamic tariff (EPEX-indexed)
 
-Customers on ENGIE's dynamic (EPEX-indexed) electricity contract get three
+Customers on ENGIE's dynamic (EPEX-indexed) electricity contract get four
 extra sensors that surface day-ahead wholesale prices from the public EPEX
 endpoint.
 
 | Sensor | Entity ID |
 |---|---|
 | EPEX current price | `sensor.engie_belgium_epex_current_price` |
+| EPEX next hour price | `sensor.engie_belgium_epex_next_hour_price` |
 | EPEX lowest price today | `sensor.engie_belgium_epex_lowest_price_today` |
 | EPEX highest price today | `sensor.engie_belgium_epex_highest_price_today` |
 
-All three sensors are in **EUR/kWh** (4 decimals). Tomorrow's prices appear
+All four sensors are in **EUR/kWh** (4 decimals). Tomorrow's prices appear
 once ENGIE publishes them, typically shortly after 13:15 Europe/Brussels.
 
 The current-price sensor exposes the full today / tomorrow slate as

--- a/custom_components/engie_be/sensor.py
+++ b/custom_components/engie_be/sensor.py
@@ -565,13 +565,21 @@ _EPEX_HIGH_TODAY = SensorEntityDescription(
     state_class=SensorStateClass.MEASUREMENT,
     suggested_display_precision=_EPEX_PRECISION,
 )
+_EPEX_NEXT_HOUR = SensorEntityDescription(
+    key="epex_next_hour",
+    translation_key="epex_next_hour",
+    icon="mdi:cash-fast",
+    native_unit_of_measurement=_EPEX_UNIT,
+    state_class=SensorStateClass.MEASUREMENT,
+    suggested_display_precision=_EPEX_PRECISION,
+)
 
 
 def _build_epex_sensors(
     epex_coordinator: EngieBeEpexCoordinator,
     subentry: ConfigSubentry,
 ) -> list[SensorEntity]:
-    """Build the three shared EPEX day-ahead sensors for one subentry."""
+    """Build the four shared EPEX day-ahead sensors for one subentry."""
     return [
         EngieBeEpexCurrentSensor(epex_coordinator, subentry, _EPEX_CURRENT),
         EngieBeEpexExtremaSensor(
@@ -580,6 +588,7 @@ def _build_epex_sensors(
         EngieBeEpexExtremaSensor(
             epex_coordinator, subentry, _EPEX_HIGH_TODAY, mode="max"
         ),
+        EngieBeEpexNextHourSensor(epex_coordinator, subentry, _EPEX_NEXT_HOUR),
     ]
 
 
@@ -684,6 +693,50 @@ class EngieBeEpexCurrentSensor(_EngieBeEpexSensorBase):
                 self.coordinator.last_update_success_time.isoformat()
             )
         return attrs
+
+
+class EngieBeEpexNextHourSensor(_EngieBeEpexSensorBase):
+    """EPEX day-ahead price for the slot starting one hour from now."""
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the EUR/kWh price of the slot covering ``now + 1h``."""
+        payload = _epex_payload(self.coordinator)
+        if payload is None:
+            return None
+        target = dt_util.utcnow() + timedelta(hours=1)
+        for slot in payload.slots:
+            if slot.start <= target < slot.end:
+                return slot.value_eur_per_kwh
+        return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """
+        Expose the start/end of the slot whose price is being reported.
+
+        Intentionally narrower than :class:`EngieBeEpexCurrentSensor`'s
+        attribute set: this is a point lookup for one specific future
+        slot, not a today/tomorrow slate browser, so the per-day arrays
+        and market metadata are omitted to keep the entity focused.
+        """
+        payload = _epex_payload(self.coordinator)
+        if payload is None:
+            return {}
+        target = dt_util.utcnow() + timedelta(hours=1)
+        for slot in payload.slots:
+            if slot.start <= target < slot.end:
+                attrs: dict[str, Any] = {
+                    "slot_start": slot.start.isoformat(),
+                    "slot_end": slot.end.isoformat(),
+                    "slot_duration_minutes": slot.duration_minutes,
+                }
+                if self.coordinator.last_update_success_time is not None:
+                    attrs["last_fetched"] = (
+                        self.coordinator.last_update_success_time.isoformat()
+                    )
+                return attrs
+        return {}
 
 
 class EngieBeEpexExtremaSensor(_EngieBeEpexSensorBase):

--- a/custom_components/engie_be/strings.json
+++ b/custom_components/engie_be/strings.json
@@ -255,6 +255,9 @@
             },
             "epex_high_today": {
                 "name": "EPEX highest price today"
+            },
+            "epex_next_hour": {
+                "name": "EPEX next hour price"
             }
         },
         "binary_sensor": {

--- a/tests/test_sensor_epex.py
+++ b/tests/test_sensor_epex.py
@@ -15,8 +15,10 @@ from custom_components.engie_be.sensor import (
     _EPEX_CURRENT,
     _EPEX_HIGH_TODAY,
     _EPEX_LOW_TODAY,
+    _EPEX_NEXT_HOUR,
     EngieBeEpexCurrentSensor,
     EngieBeEpexExtremaSensor,
+    EngieBeEpexNextHourSensor,
     _build_epex_sensors,
 )
 
@@ -104,9 +106,9 @@ def _make_epex_coordinator(
 # ---------------------------------------------------------------------------
 
 
-def test_build_epex_sensors_creates_three_entities() -> None:
+def test_build_epex_sensors_creates_four_entities() -> None:
     """
-    The builder always returns the three documented EPEX sensors.
+    The builder always returns the four documented EPEX sensors.
 
     The set + count is part of the public contract; a regression here
     would break user dashboards. Unique IDs are subentry-scoped because
@@ -120,7 +122,12 @@ def test_build_epex_sensors_creates_three_entities() -> None:
     sensors = _build_epex_sensors(coordinator, subentry)
 
     keys = {s.entity_description.key for s in sensors}
-    assert keys == {"epex_current", "epex_low_today", "epex_high_today"}
+    assert keys == {
+        "epex_current",
+        "epex_low_today",
+        "epex_high_today",
+        "epex_next_hour",
+    }
     for sensor in sensors:
         assert sensor.unique_id == (
             f"test_entry_id_sub_xyz_{sensor.entity_description.key}"
@@ -136,7 +143,7 @@ def test_build_epex_sensors_runs_without_payload() -> None:
     """
     coordinator = _make_epex_coordinator(None)
     subentry = _make_subentry()
-    assert len(_build_epex_sensors(coordinator, subentry)) == 3
+    assert len(_build_epex_sensors(coordinator, subentry)) == 4
 
 
 # ---------------------------------------------------------------------------
@@ -327,7 +334,8 @@ def test_low_today_sensor_selects_minimum_of_today_only() -> None:
         today=[(8, 0.115), (14, -0.0123), (18, 0.19840)],
         tomorrow=[(14, -0.5)],  # Lower than today, but must be ignored.
     )
-    coordinator = _make_epex_coordinator(payload)
+    last_fetch = datetime(2026, 5, 4, 13, 7, 21, tzinfo=UTC)
+    coordinator = _make_epex_coordinator(payload, last_fetch=last_fetch)
     subentry = _make_subentry()
     sensor = EngieBeEpexExtremaSensor(
         coordinator,
@@ -346,6 +354,7 @@ def test_low_today_sensor_selects_minimum_of_today_only() -> None:
     assert attrs["slot_start"] == "2026-05-04T14:00:00+02:00"
     assert attrs["slot_end"] == "2026-05-04T15:00:00+02:00"
     assert attrs["slot_duration_minutes"] == 60
+    assert attrs["last_fetched"] == last_fetch.isoformat()
 
 
 def test_high_today_sensor_selects_maximum_of_today_only() -> None:
@@ -420,6 +429,26 @@ def test_extrema_sensor_rejects_invalid_mode() -> None:
         )
 
 
+def test_extrema_sensor_native_value_is_none_without_payload() -> None:
+    """
+    ``native_value`` returns ``None`` when no payload is cached.
+
+    ``available`` already gates the entity to ``unavailable`` in this
+    state, but the value path is exercised independently to defend
+    against future changes that decouple the two (e.g. an availability
+    refactor that no longer short-circuits on payload presence).
+    """
+    coordinator = _make_epex_coordinator(None)
+    subentry = _make_subentry()
+    sensor = EngieBeEpexExtremaSensor(
+        coordinator,
+        subentry,
+        _EPEX_LOW_TODAY,
+        mode="min",
+    )
+    assert sensor.native_value is None
+
+
 # ---------------------------------------------------------------------------
 # Entity description metadata
 # ---------------------------------------------------------------------------
@@ -435,7 +464,7 @@ def test_epex_sensors_use_eur_per_kwh_unit_and_measurement_state_class() -> None
     State class must be MEASUREMENT (not TOTAL_INCREASING) because
     wholesale prices can go negative and reset arbitrarily.
     """
-    for desc in (_EPEX_CURRENT, _EPEX_LOW_TODAY, _EPEX_HIGH_TODAY):
+    for desc in (_EPEX_CURRENT, _EPEX_LOW_TODAY, _EPEX_HIGH_TODAY, _EPEX_NEXT_HOUR):
         assert desc.native_unit_of_measurement == "EUR/kWh"
         assert desc.state_class == SensorStateClass.MEASUREMENT
         assert desc.device_class is None
@@ -444,3 +473,98 @@ def test_epex_sensors_use_eur_per_kwh_unit_and_measurement_state_class() -> None
         assert desc.suggested_display_precision == 4
         # Translation key must match strings.json entries.
         assert desc.translation_key == desc.key
+
+
+# ---------------------------------------------------------------------------
+# Next-hour sensor
+# ---------------------------------------------------------------------------
+
+
+def test_next_hour_sensor_picks_slot_covering_now_plus_one_hour() -> None:
+    """
+    ``native_value`` must return the price of the slot containing ``now+1h``.
+
+    With the 15:30 Brussels anchor, ``now+1h`` is 16:30, which falls
+    inside the 16:00 slot. The 15:00 slot (current) and the 17:00 slot
+    must NOT be selected -- a regression here would either re-publish
+    the current price or skip a slot ahead.
+    """
+    payload = _build_payload(
+        [
+            (15, 0.02565),
+            (16, 0.08040),
+            (17, 0.11200),
+        ],
+    )
+    last_fetch = datetime(2026, 5, 4, 13, 7, 21, tzinfo=UTC)
+    coordinator = _make_epex_coordinator(payload, last_fetch=last_fetch)
+    subentry = _make_subentry()
+    sensor = EngieBeEpexNextHourSensor(coordinator, subentry, _EPEX_NEXT_HOUR)
+
+    with patch(
+        "custom_components.engie_be.sensor.dt_util.utcnow",
+        return_value=_NOW_UTC,
+    ):
+        assert sensor.native_value == pytest.approx(0.08040)
+        attrs = sensor.extra_state_attributes
+
+    assert attrs["slot_start"] == "2026-05-04T16:00:00+02:00"
+    assert attrs["slot_end"] == "2026-05-04T17:00:00+02:00"
+    assert attrs["slot_duration_minutes"] == 60
+    assert attrs["last_fetched"] == last_fetch.isoformat()
+
+
+def test_next_hour_sensor_crosses_midnight_into_tomorrow() -> None:
+    """
+    ``next_hour`` must follow into tomorrow's slate when ``now+1h`` does.
+
+    Late-evening anchor (23:30 Brussels) means ``now+1h`` is 00:30 the
+    next day, so the sensor must surface tomorrow's 00:00 slot rather
+    than fall back to ``None``.
+    """
+    payload = _build_payload(
+        today=[(23, 0.07000)],
+        tomorrow=[(0, 0.04500), (1, 0.04200)],
+    )
+    coordinator = _make_epex_coordinator(payload)
+    subentry = _make_subentry()
+    sensor = EngieBeEpexNextHourSensor(coordinator, subentry, _EPEX_NEXT_HOUR)
+
+    late_brussels = datetime(2026, 5, 4, 23, 30, 0, tzinfo=_BRUSSELS)
+    late_utc = late_brussels.astimezone(UTC)
+    with patch(
+        "custom_components.engie_be.sensor.dt_util.utcnow",
+        return_value=late_utc,
+    ):
+        assert sensor.native_value == pytest.approx(0.04500)
+
+
+def test_next_hour_sensor_returns_none_when_no_covering_slot() -> None:
+    """
+    No covering slot -> ``None`` value, empty attributes.
+
+    If the cached EPEX payload is too old (or tomorrow's slate is not
+    yet published in the late-evening window), ``native_value`` is
+    ``None`` and attributes are empty so we don't surface a stale slot.
+    """
+    # Slots only cover 14:00 and 15:00; ``now+1h`` (16:30) falls outside.
+    payload = _build_payload([(14, -0.0123), (15, 0.02565)])
+    coordinator = _make_epex_coordinator(payload)
+    subentry = _make_subentry()
+    sensor = EngieBeEpexNextHourSensor(coordinator, subentry, _EPEX_NEXT_HOUR)
+
+    with patch(
+        "custom_components.engie_be.sensor.dt_util.utcnow",
+        return_value=_NOW_UTC,
+    ):
+        assert sensor.native_value is None
+        assert sensor.extra_state_attributes == {}
+
+
+def test_next_hour_sensor_native_value_is_none_when_unavailable() -> None:
+    """No payload -> native_value None (mirrors the current sensor)."""
+    coordinator = _make_epex_coordinator(None)
+    subentry = _make_subentry()
+    sensor = EngieBeEpexNextHourSensor(coordinator, subentry, _EPEX_NEXT_HOUR)
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes == {}

--- a/tests/test_sensor_peaks.py
+++ b/tests/test_sensor_peaks.py
@@ -142,6 +142,40 @@ def test_monthly_peak_value_returns_none_when_peaks_missing() -> None:
     assert sensor.native_value is None
 
 
+def test_monthly_peak_value_returns_none_when_field_missing() -> None:
+    """
+    Missing or non-numeric peak fields yield ``None`` rather than raising.
+
+    Exercises the three defensive branches that protect against ENGIE
+    payload drift: the ``peakOfTheMonth`` dict is present but the
+    requested field is absent, ``None``, or non-coercible (a list / a
+    non-numeric string).
+    """
+    base = _wrap(_peaks())
+    # 1. Field absent entirely -> None
+    base["data"]["peakOfTheMonth"] = {"start": "2026-04-15T18:00:00+02:00"}
+    coordinator = _make_coordinator({"peaks": base})
+    subentry = _make_subentry()
+    sensors = _build_peak_sensors(coordinator, subentry)
+    sensor = EngieBeMonthlyPeakValueSensor(
+        coordinator,
+        subentry,
+        sensors[0].entity_description,
+        field="peakKW",
+    )
+    assert sensor.native_value is None
+
+    # 2. Field present but non-coercible to float (TypeError on float([...]))
+    base["data"]["peakOfTheMonth"] = {"peakKW": [1, 2, 3]}
+    coordinator.data = {"peaks": base}
+    assert sensor.native_value is None
+
+    # 3. Field present but unparseable string (ValueError on float("abc"))
+    base["data"]["peakOfTheMonth"] = {"peakKW": "abc"}
+    coordinator.data = {"peaks": base}
+    assert sensor.native_value is None
+
+
 # ---------------------------------------------------------------------------
 # Monthly timestamp sensor
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a fourth EPEX day-ahead sensor for dynamic-tariff (EPEX-indexed) electricity accounts:

- `sensor.engie_be_<can>_epex_next_hour` — wholesale price (EUR/kWh) of the slot covering `now + 1h`

Useful for short-horizon load shifting ("start the dishwasher when the next hour is cheap") without having to parse the today/tomorrow attribute arrays in a template.

## Behaviour

- **Native value:** EUR/kWh, 4 decimals, `state_class=MEASUREMENT`. No `device_class` (consistent with the three sibling EPEX sensors — `MONETARY` requires a bare ISO-4217 currency code and rejects the compound `EUR/kWh` form).
- **Slot selection:** iterates `payload.slots` and returns the slot where `slot.start <= utcnow()+1h < slot.end`. Crosses midnight cleanly — at 23:30 Brussels-local, the sensor reports tomorrow's 00:00 slot.
- **Returns `None`** when:
  - No cached payload (entity gates to `unavailable` via inherited `available` guard).
  - Cached payload has no slot covering `now+1h` (rare; e.g. tomorrow's slate not yet published late in the day).
- **Attributes:** `slot_start`, `slot_end`, `slot_duration_minutes`, plus `last_fetched` when the coordinator has succeeded at least once. Intentionally narrower than `EngieBeEpexCurrentSensor`'s today/tomorrow slate — this is a point lookup, not a slate browser. Rationale documented inline.
- **Setup gating:** unchanged. Added unconditionally on dynamic accounts via the existing `_build_epex_sensors` helper, gated upstream by `coordinator.is_dynamic`.

## Test coverage

- `tests/test_sensor_epex.py`:
  - `test_build_epex_sensors_creates_four_entities` (was three)
  - Metadata loop extended to include `_EPEX_NEXT_HOUR`
  - 4 next-hour cases: covering-slot happy path (asserts `last_fetched`), midnight crossover into tomorrow, no covering slot returns None, payload absent returns None
  - `test_extrema_sensor_native_value_is_none_without_payload` (defensive branch)
  - Extrema-low test extended to assert `last_fetched`
- `tests/test_sensor_peaks.py`:
  - `test_monthly_peak_value_returns_none_when_field_missing` covering field-absent / TypeError on list / ValueError on `"abc"` defensive branches

Sensor class itself: 100% line coverage. Total project coverage: **85.17%** (≥ 85% floor enforced by `--cov-fail-under=85`).

## Notes

- `manifest.json` version intentionally **not** bumped per AGENTS.md and PR #64 precedent (version bumps reserved for release PRs).
- `CHANGELOG.md` `## [Unreleased] ### Added` entry included; PR link will be appended at release time.
- `README.md` Dynamic tariff section updated (3 → 4 sensors).
- `strings.json` updated; `translations/en.json` not touched (auto-synced).
- Behaviour validated against current HA developer docs (sensor entity description, `extra_state_attributes` semantics, `state_class=MEASUREMENT` for non-total numeric values, ConfigSubentry-scoped unique IDs).
- No `tests/test_migrate_entry.py` change needed: `epex_next_hour` never existed in the v2 schema, so it has nothing to migrate.