### PR TITLE
chore: release 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.2] - 2026-05-07
 
 ### Added
 - **New `EPEX next hour price` sensor** for dynamic-tariff
@@ -306,7 +306,8 @@ No user-visible changes.
 [#59]: https://github.com/DaanVervacke/hass-engie-be/pull/59
 [#61]: https://github.com/DaanVervacke/hass-engie-be/pull/61
 
-[Unreleased]: https://github.com/DaanVervacke/hass-engie-be/compare/v0.8.1...HEAD
+[Unreleased]: https://github.com/DaanVervacke/hass-engie-be/compare/v0.8.2...HEAD
+[0.8.2]: https://github.com/DaanVervacke/hass-engie-be/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/DaanVervacke/hass-engie-be/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/DaanVervacke/hass-engie-be/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/DaanVervacke/hass-engie-be/compare/v0.7.0...v0.7.1

--- a/custom_components/engie_be/manifest.json
+++ b/custom_components/engie_be/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.engie_be"
   ],
   "quality_scale": "bronze",
-  "version": "0.8.1"
+  "version": "0.8.2"
 }


### PR DESCRIPTION
## Summary
Release v0.8.2.

### Added
- New `EPEX next hour price` sensor for dynamic-tariff electricity accounts (#76).

## Changes
- Bump `manifest.json` version `0.8.1` → `0.8.2`.
- Promote `[Unreleased]` → `[0.8.2] - 2026-05-07` in `CHANGELOG.md`; add `[0.8.2]` compare link.