### PR TITLE
chore(api): add structured DEBUG logging with redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
   auth pages full of CSRF tokens. No behaviour changes; logging is
   only emitted when the integration logger is at DEBUG.
 
+### Fixed
+- **DEBUG logging redaction:** the Auth0 login form body printed the
+  user's email (`username` field) and the opaque flow `state` token
+  verbatim because neither key was in the body redaction sets. Both
+  are now masked: `username` is partial-masked (last-4 preserved) and
+  `state` is fully masked, on both the JSON and form-encoded body
+  paths. Affects users who enabled DEBUG logging on the unreleased
+  `chore/improve-debug-logging` beta -- previously logged sessions
+  should be considered leaked and the log files scrubbed.
+
 ### Internal
 - Extracted `_log_request` / `_log_response` / `_log_error` helpers
   in `api.py` so the `_api_wrapper` and EPEX inline paths share a
@@ -26,6 +36,9 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
   the conscious divergence from `homeassistant.components.diagnostics`
   `async_redact_data` (we need case-insensitive header matching and
   tail-preserving partial masks for greppable PII identifiers).
+- Form-encoded body redaction now applies the partial-mask key set
+  (previously full-mask only), so PII fields posted through OAuth /
+  Auth0 endpoints are masked the same way as JSON bodies.
 
 ## [0.8.2] - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **Structured DEBUG-level request/response logging** in the ENGIE
+  Belgium API client. Each HTTP call is bracketed with paired `→` /
+  `←` (or `✗` on failure) log lines tagged with an 8-character
+  correlation ID and elapsed milliseconds. URL query parameters,
+  request headers, request bodies, and response bodies are recursively
+  redacted: tokens are fully masked, while emails, EAN identifiers,
+  and customer IDs are partially masked (last 4 chars preserved).
+  HTML bodies are truncated to 120 characters to avoid dumping live
+  auth pages full of CSRF tokens. No behaviour changes; logging is
+  only emitted when the integration logger is at DEBUG.
+
+### Internal
+- Extracted `_log_request` / `_log_response` / `_log_error` helpers
+  in `api.py` so the `_api_wrapper` and EPEX inline paths share a
+  single source of truth for the `→ / ← / ✗` log format. Documented
+  the conscious divergence from `homeassistant.components.diagnostics`
+  `async_redact_data` (we need case-insensitive header matching and
+  tail-preserving partial masks for greppable PII identifiers).
+
 ## [0.8.2] - 2026-05-07
 
 ### Added

--- a/custom_components/engie_be/api.py
+++ b/custom_components/engie_be/api.py
@@ -4,15 +4,20 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import json
+import logging
 import os
 import re
 import socket
+import time
 import uuid
 from base64 import urlsafe_b64encode
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from http import HTTPStatus
 from typing import Any, NoReturn
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import aiohttp
 
@@ -126,6 +131,407 @@ def _extract_from_body(body: str, pattern: str) -> str | None:
     """Extract a value from an HTML body using a regex pattern."""
     match = re.search(pattern, body)
     return match.group(1) if match else None
+
+
+# ---------------------------------------------------------------------------
+# Debug-logging helpers
+# ---------------------------------------------------------------------------
+#
+# Centralised redaction so DEBUG-level request/response logging can never
+# leak tokens, credentials, or PII.  Everything below is gated behind
+# ``LOGGER.isEnabledFor(logging.DEBUG)`` at the call sites so the cost on
+# the hot token-refresh path is one branch when debug is off.
+#
+# We deliberately do NOT use ``homeassistant.components.diagnostics``
+# ``async_redact_data`` even though it has overlapping recursive-walk
+# semantics.  Two features we need that it lacks:
+#   1. Case-insensitive key matching -- HTTP headers arrive with
+#      arbitrary casing (``Authorization`` vs ``authorization``) and we
+#      want a single key set to match both.
+#   2. Partial masking with tail-preservation (``***0001``) -- the
+#      ENGIE API returns EAN, customer-account, and similar identifiers
+#      whose tail is the only useful greppable token in support logs.
+#      ``async_redact_data`` only does full replacement
+#      (``"**REDACTED**"``).
+# Audit finding 2 documents this divergence; revisit if HA core grows
+# either feature upstream.
+
+_REDACTED = "***"
+
+# Header keys whose values must never be logged verbatim.  Compared
+# case-insensitively against header names actually sent on the wire.
+_REDACT_HEADER_KEYS: frozenset[str] = frozenset(
+    {
+        "authorization",
+        "cookie",
+        "set-cookie",
+        "x-csrf-token",
+    }
+)
+
+# JSON / form-body keys whose values are credentials, tokens, OAuth
+# secrets, or PKCE material.  Fully masked (``***``) recursively in any
+# nested dict.
+_REDACT_BODY_KEYS: frozenset[str] = frozenset(
+    {
+        "password",
+        "code",
+        "otp",
+        "access_token",
+        "refresh_token",
+        "id_token",
+        "code_verifier",
+        "code_challenge",
+        "client_secret",
+    }
+)
+
+# JSON / form-body keys carrying account-identifying PII surfaced by
+# the ENGIE API (relations, contracts, prices, peaks, service-points).
+# These are partially masked via ``_redact_text`` so log lines stay
+# greppable (e.g. ``***0001`` for an EAN tail) without leaking the full
+# identifier.  Compared case-insensitively against the JSON keys
+# returned on the wire.
+_PARTIAL_MASK_BODY_KEYS: frozenset[str] = frozenset(
+    {
+        # Identifiers
+        "ean",
+        "customeraccountnumber",
+        "businessagreementnumber",
+        "premisesnumber",
+        # Contact / personal
+        "name",
+        "firstname",
+        "lastname",
+        "email",
+        "emailaddress",
+        "phonenumber",
+        "mobilephonenumber",
+        # Address components
+        "street",
+        "housenumber",
+        "postalcode",
+        "city",
+    }
+)
+
+# Query-string keys carrying OAuth/PKCE state worth masking.  ``state``
+# is sensitive because it gates the auth flow; the verifier and
+# challenge are PKCE secrets.
+_REDACT_QUERY_KEYS: frozenset[str] = frozenset(
+    {
+        "code",
+        "state",
+        "code_verifier",
+        "code_challenge",
+        "nonce",
+    }
+)
+
+# Maximum HTML preview length kept in DEBUG logs.  Auth-flow HTML
+# responses are 50-200 KB and contain live CSRF tokens; we never log
+# the body in full.
+_HTML_PREVIEW_MAX = 120
+
+
+def _redact_text(value: str | None, keep: int = 4) -> str:
+    """
+    Mask all but the trailing *keep* characters of *value*.
+
+    Used for emails, EAN, customer-account numbers, and refresh-token
+    tails so log lines remain greppable without leaking the secret.
+    ``None`` and empty values are passed through unchanged.
+    """
+    if value is None:
+        return "<none>"
+    if not value:
+        return ""
+    if len(value) <= keep:
+        return _REDACTED
+    return f"{_REDACTED}{value[-keep:]}"
+
+
+def _redact_mapping(
+    data: Mapping[str, Any],
+    keys: frozenset[str],
+    partial_keys: frozenset[str] | None = None,
+) -> dict[str, Any]:
+    """
+    Return a copy of *data* with sensitive values masked.
+
+    Values whose key (case-insensitive) is in *keys* are replaced by
+    ``***``.  Values whose key is in *partial_keys* are passed through
+    ``_redact_text`` so the trailing 4 chars are kept for greppability
+    (intended for account-identifying PII like EAN / customer numbers
+    / addresses).  Dict values are recursed into; lists of dicts are
+    walked too.  Non-mapping inputs are returned as ``{}``.
+    """
+    if not isinstance(data, Mapping):
+        return {}
+    partial = partial_keys or frozenset()
+    result: dict[str, Any] = {}
+    for key, value in data.items():
+        key_lc = key.lower()
+        if key_lc in keys:
+            result[key] = _REDACTED
+        elif key_lc in partial:
+            # Partial-mask scalars; recurse into nested dicts/lists so
+            # an "address" sub-dict's "street" still gets masked.
+            if isinstance(value, str):
+                result[key] = _redact_text(value)
+            elif isinstance(value, (int, float)):
+                result[key] = _redact_text(str(value))
+            elif isinstance(value, Mapping):
+                result[key] = _redact_mapping(value, keys, partial)
+            elif isinstance(value, list):
+                result[key] = [
+                    _redact_mapping(item, keys, partial)
+                    if isinstance(item, Mapping)
+                    else (_redact_text(item) if isinstance(item, str) else item)
+                    for item in value
+                ]
+            else:
+                result[key] = _REDACTED
+        elif isinstance(value, Mapping):
+            result[key] = _redact_mapping(value, keys, partial)
+        elif isinstance(value, list):
+            result[key] = [
+                _redact_mapping(item, keys, partial)
+                if isinstance(item, Mapping)
+                else item
+                for item in value
+            ]
+        else:
+            result[key] = value
+    return result
+
+
+def _redact_url(url: str) -> str:
+    """
+    Return *url* with sensitive query-string parameters redacted.
+
+    Path and host are left intact (they are needed to identify which
+    endpoint was hit).  Only the query string is rewritten.
+    """
+    if "?" not in url:
+        return url
+    parts = urlsplit(url)
+    pairs = parse_qsl(parts.query, keep_blank_values=True)
+    redacted_pairs = [
+        (k, _REDACTED if k.lower() in _REDACT_QUERY_KEYS else v) for k, v in pairs
+    ]
+    return urlunsplit(parts._replace(query=urlencode(redacted_pairs)))
+
+
+def _redact_body(body: Any, content_type: str | None) -> str:  # noqa: PLR0911, PLR0912
+    """
+    Render *body* for DEBUG logs with credentials masked.
+
+    JSON bodies are parsed, then both the credential keys
+    (``_REDACT_BODY_KEYS``, fully masked) and the PII keys
+    (``_PARTIAL_MASK_BODY_KEYS``, last-4-chars preserved) are walked
+    recursively before re-serialisation.
+    ``application/x-www-form-urlencoded`` strings are parsed, redacted,
+    and re-rendered.  ``text/html`` (or anything HTML-shaped) is
+    truncated to ``_HTML_PREVIEW_MAX`` chars to avoid dumping live
+    auth pages full of CSRF tokens.  Anything else is rendered with
+    ``repr`` and returned as-is (no length cap; per integration debug
+    policy non-HTML bodies are logged in full).
+    """
+    # NB: do NOT collapse to ``body in {b"", ""}`` -- ``body`` may be a
+    # dict / list (unhashable) which raises TypeError. The empty-body
+    # tests cover this; ruff PLR1714 disagrees but is wrong here.
+    if body is None or body == b"" or body == "":  # noqa: PLR1714
+        return "<empty>"
+
+    ct = (content_type or "").lower()
+
+    # JSON in / JSON out.
+    if isinstance(body, (dict, list)):
+        try:
+            return (
+                json.dumps(
+                    _redact_mapping(body, _REDACT_BODY_KEYS, _PARTIAL_MASK_BODY_KEYS),
+                    default=str,
+                )
+                if isinstance(body, Mapping)
+                else json.dumps(
+                    [
+                        _redact_mapping(
+                            item, _REDACT_BODY_KEYS, _PARTIAL_MASK_BODY_KEYS
+                        )
+                        if isinstance(item, Mapping)
+                        else item
+                        for item in body
+                    ],
+                    default=str,
+                )
+            )
+        except (TypeError, ValueError):
+            return repr(body)
+
+    if isinstance(body, bytes):
+        try:
+            body = body.decode("utf-8", errors="replace")
+        except Exception:  # noqa: BLE001 - defensive; shouldn't happen with errors="replace"
+            return f"<{len(body)} bytes binary>"
+
+    if not isinstance(body, str):
+        return repr(body)
+
+    # HTML response: truncated preview only.
+    if "html" in ct or body.lstrip().startswith(("<!DOCTYPE", "<html", "<HTML")):
+        preview = body[:_HTML_PREVIEW_MAX]
+        return f"<html len={len(body)} preview={preview!r}>"
+
+    # JSON string: try to parse + redact.
+    if "json" in ct or body.lstrip().startswith(("{", "[")):
+        try:
+            parsed = json.loads(body)
+        except ValueError:
+            return body
+        if isinstance(parsed, Mapping):
+            return json.dumps(
+                _redact_mapping(parsed, _REDACT_BODY_KEYS, _PARTIAL_MASK_BODY_KEYS),
+                default=str,
+            )
+        if isinstance(parsed, list):
+            return json.dumps(
+                [
+                    _redact_mapping(item, _REDACT_BODY_KEYS, _PARTIAL_MASK_BODY_KEYS)
+                    if isinstance(item, Mapping)
+                    else item
+                    for item in parsed
+                ],
+                default=str,
+            )
+        return body
+
+    # Form-encoded: parse + redact.  Only credential keys are masked
+    # here (form bodies are used for OAuth / login posts, not for
+    # PII-bearing API responses).
+    if "form-urlencoded" in ct or ("=" in body and "&" in body and " " not in body):
+        try:
+            pairs = parse_qsl(body, keep_blank_values=True)
+        except ValueError:
+            return body
+        if pairs:
+            return urlencode(
+                [
+                    (k, _REDACTED if k.lower() in _REDACT_BODY_KEYS else v)
+                    for k, v in pairs
+                ]
+            )
+
+    # Plain text: passthrough.
+    return body
+
+
+def _new_req_id() -> str:
+    """Return an 8-char correlation ID for one request/response pair."""
+    return uuid.uuid4().hex[:8]
+
+
+# ---------------------------------------------------------------------------
+# Structured request / response logging helpers
+# ---------------------------------------------------------------------------
+#
+# Both ``_api_wrapper`` and the inline EPEX path emit identical
+# ``→ / ← / ✗`` lines.  Centralising them here avoids the two paths
+# drifting (audit finding 5).  Callers gate on
+# ``LOGGER.isEnabledFor(logging.DEBUG)`` themselves so that on the
+# disabled-debug hot path we pay one branch, not three; the helpers
+# therefore assume DEBUG is on and never re-check.
+
+
+def _log_request(  # noqa: PLR0913
+    req_id: str,
+    method: str,
+    url: str,
+    *,
+    params: Mapping[str, Any] | None,
+    headers: Mapping[str, str] | None,
+    body: Any,
+) -> None:
+    """Emit the ``→`` line for an outgoing request."""
+    req_ct = (headers or {}).get("Content-Type") or (headers or {}).get("content-type")
+    LOGGER.debug(
+        "→ %s %s [req_id=%s] params=%s headers=%s body=%s",
+        method,
+        _redact_url(url),
+        req_id,
+        _redact_mapping(params or {}, _REDACT_QUERY_KEYS),
+        _redact_mapping(headers or {}, _REDACT_HEADER_KEYS),
+        _redact_body(body, req_ct) if body is not None else "<empty>",
+    )
+
+
+def _log_response(  # noqa: PLR0913
+    req_id: str,
+    method: str,
+    url: str,
+    *,
+    status: int,
+    started: float,
+    ct: str | None,
+    body: Any,
+) -> None:
+    """Emit the ``←`` line for a successful response."""
+    LOGGER.debug(
+        "← %s %s [req_id=%s] status=%d in %.0fms ct=%s body=%s",
+        method,
+        _redact_url(url),
+        req_id,
+        status,
+        (time.monotonic() - started) * 1000,
+        ct,
+        _redact_body(body, ct),
+    )
+
+
+def _log_error(  # noqa: PLR0913
+    req_id: str,
+    method: str,
+    url: str,
+    started: float,
+    *,
+    status: int | None = None,
+    body: Any = None,
+    ct: str | None = None,
+    exc_name: str | None = None,
+    suffix: str | None = None,
+    exc_info: bool = False,
+) -> None:
+    """
+    Emit the ``✗`` line for any error path.
+
+    The format is built dynamically from whichever of *status* /
+    *exc_name* / *body* / *suffix* is supplied so a single helper
+    covers HTTP-error, timeout, ClientError, EPEX-404, and bare-
+    ``Exception`` variants without forcing each call site to assemble
+    the format string.
+    """
+    parts = ["✗ %s %s [req_id=%s]"]
+    args: list[Any] = [method, _redact_url(url), req_id]
+
+    if status is not None:
+        parts.append("status=%d")
+        args.append(status)
+    if exc_name is not None:
+        parts.append("%s")
+        args.append(exc_name)
+
+    parts.append("in %.0fms")
+    args.append((time.monotonic() - started) * 1000)
+
+    if body is not None:
+        parts.append("body=%s")
+        args.append(_redact_body(body, ct))
+
+    fmt = " ".join(parts)
+    if suffix:
+        fmt = f"{fmt} {suffix}"
+    LOGGER.debug(fmt, *args, exc_info=exc_info)
 
 
 # ---------------------------------------------------------------------------
@@ -247,6 +653,9 @@ class EngieBeApiClient:
             "User-Agent": USER_AGENT_NATIVE,
         }
 
+        debug_on = LOGGER.isEnabledFor(logging.DEBUG)
+        old_refresh_tail = _redact_text(self.refresh_token) if debug_on else ""
+
         result = await self._api_wrapper(
             session=self._session,
             method="POST",
@@ -258,6 +667,15 @@ class EngieBeApiClient:
 
         self.access_token = result["access_token"]
         self.refresh_token = result["refresh_token"]
+
+        if debug_on:
+            LOGGER.debug(
+                "Token refresh: rotated refresh_token %s → %s, expires_in=%s",
+                old_refresh_tail,
+                _redact_text(self.refresh_token),
+                result.get("expires_in"),
+            )
+
         return self.access_token, self.refresh_token
 
     # ------------------------------------------------------------------
@@ -479,6 +897,20 @@ class EngieBeApiClient:
         # status visibility to distinguish 404 from real failures, so
         # call session.request directly here -- mirroring _api_wrapper's
         # error mapping but without its 401/403 handling.
+        debug_on = LOGGER.isEnabledFor(logging.DEBUG)
+        req_id = _new_req_id() if debug_on else ""
+        started = time.monotonic() if debug_on else 0.0
+
+        if debug_on:
+            _log_request(
+                req_id,
+                "GET",
+                EPEX_BASE_URL,
+                params=params,
+                headers=headers,
+                body=None,
+            )
+
         try:
             async with asyncio.timeout(30):
                 response = await self._session.request(
@@ -490,6 +922,15 @@ class EngieBeApiClient:
                 )
                 status = response.status
                 if status == HTTPStatus.NOT_FOUND:
+                    if debug_on:
+                        _log_error(
+                            req_id,
+                            "GET",
+                            EPEX_BASE_URL,
+                            started,
+                            status=status,
+                            suffix="(EPEX not yet published)",
+                        )
                     msg = (
                         "EPEX prices not yet published for "
                         f"{params['from']}..{params['to']}"
@@ -497,18 +938,62 @@ class EngieBeApiClient:
                     raise EpexNotPublishedError(msg)
                 if status >= HTTPStatus.BAD_REQUEST:
                     body_preview = (await response.text())[:200]
+                    if debug_on:
+                        _log_error(
+                            req_id,
+                            "GET",
+                            EPEX_BASE_URL,
+                            started,
+                            status=status,
+                            body=body_preview,
+                            ct=response.headers.get("Content-Type")
+                            if hasattr(response, "headers")
+                            else None,
+                        )
                     msg = f"EPEX endpoint returned HTTP {status}: {body_preview}"
                     raise EngieBeApiClientCommunicationError(msg)
-                return await response.json()
+                result = await response.json()
+                if debug_on:
+                    resp_ct = (
+                        response.headers.get("Content-Type")
+                        if hasattr(response, "headers")
+                        else None
+                    )
+                    _log_response(
+                        req_id,
+                        "GET",
+                        EPEX_BASE_URL,
+                        status=status,
+                        started=started,
+                        ct=resp_ct,
+                        body=result,
+                    )
+                return result
         except EngieBeApiClientError:
             raise
         except TimeoutError as exception:
+            if debug_on:
+                _log_error(
+                    req_id,
+                    "GET",
+                    EPEX_BASE_URL,
+                    started,
+                    exc_name="timeout",
+                )
             msg = (
                 "Timeout communicating with EPEX endpoint "
                 f"({exception.__class__.__name__})"
             )
             raise EngieBeApiClientCommunicationError(msg) from exception
         except (aiohttp.ClientError, socket.gaierror) as exception:
+            if debug_on:
+                _log_error(
+                    req_id,
+                    "GET",
+                    EPEX_BASE_URL,
+                    started,
+                    exc_name=exception.__class__.__name__,
+                )
             msg = (
                 f"Error communicating with EPEX endpoint "
                 f"({exception.__class__.__name__})"
@@ -933,7 +1418,7 @@ class EngieBeApiClient:
     # Generic request wrapper
     # ------------------------------------------------------------------
 
-    async def _api_wrapper(  # noqa: PLR0913
+    async def _api_wrapper(  # noqa: PLR0912, PLR0913
         self,
         *,
         session: aiohttp.ClientSession,
@@ -956,7 +1441,28 @@ class EngieBeApiClient:
 
         When *include_headers* is ``True`` the return value is a tuple
         of ``(body_or_json, response_headers)`` instead of just the body.
+
+        At ``DEBUG`` log level this emits one ``→`` line before the
+        request and one ``←`` (success) or ``✗`` (error) line after,
+        correlated by an 8-char ``req_id``.  Tokens, credentials, OAuth
+        state, and HTML auth-page bodies are masked / truncated; see the
+        module-level redaction helpers.  When DEBUG is off, the cost is a
+        single ``isEnabledFor`` check.
         """
+        debug_on = LOGGER.isEnabledFor(logging.DEBUG)
+        req_id = _new_req_id() if debug_on else ""
+        started = time.monotonic() if debug_on else 0.0
+
+        if debug_on:
+            _log_request(
+                req_id,
+                method,
+                url,
+                params=params,
+                headers=headers,
+                body=data,
+            )
+
         try:
             async with asyncio.timeout(30):
                 response = await session.request(
@@ -972,18 +1478,50 @@ class EngieBeApiClient:
                         HTTPStatus.UNAUTHORIZED,
                         HTTPStatus.FORBIDDEN,
                     ):
+                        if debug_on:
+                            _log_error(
+                                req_id,
+                                method,
+                                url,
+                                started,
+                                status=response.status,
+                            )
                         _raise_auth_error(response.status)
 
                     # For auth-flow HTML pages, non-200/302 is likely an
                     # error but we don't raise_for_status on 3xx since we
                     # handle redirects manually.
                     if response.status >= HTTPStatus.BAD_REQUEST:
+                        if debug_on:
+                            _log_error(
+                                req_id,
+                                method,
+                                url,
+                                started,
+                                status=response.status,
+                            )
                         response.raise_for_status()
 
                 if json_response:
                     result = await response.json()
                 else:
                     result = await response.text()
+
+                if debug_on:
+                    resp_ct = (
+                        response.headers.get("Content-Type")
+                        if hasattr(response, "headers")
+                        else None
+                    )
+                    _log_response(
+                        req_id,
+                        method,
+                        url,
+                        status=response.status,
+                        started=started,
+                        ct=resp_ct,
+                        body=result,
+                    )
 
                 if include_headers:
                     return result, dict(response.headers)
@@ -992,14 +1530,39 @@ class EngieBeApiClient:
         except EngieBeApiClientError:
             raise
         except TimeoutError as exception:
+            if debug_on:
+                _log_error(
+                    req_id,
+                    method,
+                    url,
+                    started,
+                    exc_name="timeout",
+                )
             msg = (
                 f"Timeout communicating with Engie API ({exception.__class__.__name__})"
             )
             raise EngieBeApiClientCommunicationError(msg) from exception
         except (aiohttp.ClientError, socket.gaierror) as exception:
+            if debug_on:
+                _log_error(
+                    req_id,
+                    method,
+                    url,
+                    started,
+                    exc_name=exception.__class__.__name__,
+                )
             msg = f"Error communicating with Engie API ({exception.__class__.__name__})"
             raise EngieBeApiClientCommunicationError(msg) from exception
         except Exception as exception:
+            if debug_on:
+                _log_error(
+                    req_id,
+                    method,
+                    url,
+                    started,
+                    exc_name=exception.__class__.__name__,
+                    exc_info=True,
+                )
             msg = (
                 "Unexpected error communicating with Engie API "
                 f"({exception.__class__.__name__})"

--- a/custom_components/engie_be/api.py
+++ b/custom_components/engie_be/api.py
@@ -183,6 +183,11 @@ _REDACT_BODY_KEYS: frozenset[str] = frozenset(
         "code_verifier",
         "code_challenge",
         "client_secret",
+        # Auth0 opaque flow-state token. Sent as a query param on GETs
+        # (already covered by ``_REDACT_QUERY_KEYS``) AND embedded in
+        # the form body of every POST in the login flow -- both must
+        # be masked or the login session can be replayed from a log.
+        "state",
     }
 )
 
@@ -205,6 +210,11 @@ _PARTIAL_MASK_BODY_KEYS: frozenset[str] = frozenset(
         "lastname",
         "email",
         "emailaddress",
+        # Auth0 form field on /u/login/identifier and /u/login/password
+        # carries the user's email address verbatim. Partial-masked
+        # (last-4) so support logs stay greppable without leaking the
+        # full address.
+        "username",
         "phonenumber",
         "mobilephonenumber",
         # Address components
@@ -407,21 +417,27 @@ def _redact_body(body: Any, content_type: str | None) -> str:  # noqa: PLR0911, 
             )
         return body
 
-    # Form-encoded: parse + redact.  Only credential keys are masked
-    # here (form bodies are used for OAuth / login posts, not for
-    # PII-bearing API responses).
+    # Form-encoded: parse + redact.  Both credential keys (fully
+    # masked) and PII keys (partial-masked, last-4 preserved) are
+    # walked -- the Auth0 login flow sends ``username`` (an email)
+    # alongside ``password`` and ``state`` in the same form body, so
+    # the partial-mask set must apply here too.
     if "form-urlencoded" in ct or ("=" in body and "&" in body and " " not in body):
         try:
             pairs = parse_qsl(body, keep_blank_values=True)
         except ValueError:
             return body
         if pairs:
-            return urlencode(
-                [
-                    (k, _REDACTED if k.lower() in _REDACT_BODY_KEYS else v)
-                    for k, v in pairs
-                ]
-            )
+            redacted_pairs: list[tuple[str, str]] = []
+            for k, v in pairs:
+                k_lc = k.lower()
+                if k_lc in _REDACT_BODY_KEYS:
+                    redacted_pairs.append((k, _REDACTED))
+                elif k_lc in _PARTIAL_MASK_BODY_KEYS:
+                    redacted_pairs.append((k, _redact_text(v)))
+                else:
+                    redacted_pairs.append((k, v))
+            return urlencode(redacted_pairs)
 
     # Plain text: passthrough.
     return body

--- a/tests/test_api_logging.py
+++ b/tests/test_api_logging.py
@@ -317,6 +317,51 @@ class TestRedactBody:
         assert parsed["premises"][0]["ean"] == f"{_REDACTED}0001"
         assert parsed["premises"][0]["address"]["city"] == f"{_REDACTED}sels"
 
+    def test_auth0_login_body_masks_username_and_state(self) -> None:
+        """Auth0 login POST body masks ``username`` and ``state``."""
+        # Regression for the PII leak observed in field-supplied DEBUG
+        # logs where the form body of the login POST printed
+        # ``"username": "user@example.com"`` and ``"state":
+        # "<auth0-opaque>"`` verbatim because neither key was in any
+        # redaction set.
+        body = {
+            "state": "hKFo2SBCX0xlN2JEWXJ1VVpaRk9nbjRRUE05NTluUXRhdGxOUKFur3VuaXZl",
+            "allow-passkeys": "true",
+            "username": "user.example@gmail.com",
+            "js-available": "true",
+        }
+        out = _redact_body(body, "application/json")
+        # Hard contracts: neither raw value appears in the logged string.
+        assert "user.example@gmail.com" not in out
+        assert "hKFo2SBC" not in out
+        parsed = json.loads(out)
+        # state -> fully masked (credential class wins over no class).
+        assert parsed["state"] == _REDACTED
+        # username -> partial-masked, last-4 preserved (".com").
+        assert parsed["username"].endswith(".com")
+        assert parsed["username"].startswith(_REDACTED)
+        # Non-sensitive fields untouched.
+        assert parsed["allow-passkeys"] == "true"
+        assert parsed["js-available"] == "true"
+
+    def test_auth0_login_body_form_encoded_masks_username_and_state(self) -> None:
+        """Same regression as JSON path but for form-encoded bodies."""
+        # Form-encoded bodies take a different code path inside
+        # ``_redact_body`` (parsed via ``parse_qsl`` then re-encoded),
+        # so we lock the contract on that path too.
+        body = "state=hKFo2SBC.opaque&username=user.example%40gmail.com&action=default"
+        out = _redact_body(body, "application/x-www-form-urlencoded")
+        assert "hKFo2SBC.opaque" not in out
+        assert "user.example" not in out
+        assert "user.example%40gmail.com" not in out
+        # state fully masked (URL-encoded ``***``).
+        assert "state=%2A%2A%2A" in out
+        # username partial-masked: tail (".com") preserved, body masked.
+        assert "username=" in out
+        assert ".com" in out
+        # Non-sensitive field untouched.
+        assert "action=default" in out
+
 
 # ---------------------------------------------------------------------------
 # E2E: ``_api_wrapper`` (via ``async_refresh_token``)

--- a/tests/test_api_logging.py
+++ b/tests/test_api_logging.py
@@ -1,0 +1,647 @@
+"""
+Tests for structured DEBUG-level request/response logging in ``api.py``.
+
+Two layers:
+
+1. **Redaction helper unit tests** -- exercise the pure functions
+   (``_redact_text``, ``_redact_mapping``, ``_redact_url``,
+   ``_redact_body``) directly to lock the masking contract.
+2. **End-to-end DEBUG capture** -- run requests through
+   ``_api_wrapper`` / ``async_get_epex_prices`` / ``async_refresh_token``
+   with ``caplog`` capturing the ``custom_components.engie_be`` logger
+   at DEBUG and assert that the ``→`` / ``←`` / ``✗`` lines appear,
+   share a ``req_id``, and never leak secrets.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import pytest
+
+from custom_components.engie_be.api import (
+    _HTML_PREVIEW_MAX,
+    _PARTIAL_MASK_BODY_KEYS,
+    _REDACT_BODY_KEYS,
+    _REDACT_HEADER_KEYS,
+    _REDACTED,
+    EngieBeApiClient,
+    EngieBeApiClientCommunicationError,
+    EpexNotPublishedError,
+    _redact_body,
+    _redact_mapping,
+    _redact_text,
+    _redact_url,
+)
+
+_LOGGER_NAME = "custom_components.engie_be"
+
+
+# ---------------------------------------------------------------------------
+# Redaction helper unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestRedactText:
+    """``_redact_text`` masks all but the trailing characters."""
+
+    def test_none_renders_placeholder(self) -> None:
+        """``None`` becomes the ``<none>`` sentinel."""
+        assert _redact_text(None) == "<none>"
+
+    def test_empty_string_passes_through(self) -> None:
+        """Empty input is returned unchanged."""
+        assert _redact_text("") == ""
+
+    def test_short_value_fully_redacted(self) -> None:
+        """``len(value) <= keep`` collapses to ``***`` (no leak)."""
+        # Leaking 3 chars of a 4-char secret still leaks too much.
+        assert _redact_text("abcd", keep=4) == _REDACTED
+
+    def test_long_value_keeps_tail(self) -> None:
+        """Tail of the configured length is preserved."""
+        masked = _redact_text("user@example.com", keep=4)
+        assert masked == f"{_REDACTED}.com"
+
+    def test_keep_parameter_respected(self) -> None:
+        """The ``keep`` argument controls how many tail chars survive."""
+        masked = _redact_text("541448XXXXXXXX1234", keep=4)
+        assert masked.endswith("1234")
+        assert "541448" not in masked
+
+
+class TestRedactMapping:
+    """``_redact_mapping`` recursively masks listed keys."""
+
+    def test_top_level_redaction(self) -> None:
+        """Top-level keys named in the redact set are masked."""
+        out = _redact_mapping({"password": "hunter2", "user": "x"}, _REDACT_BODY_KEYS)
+        assert out == {"password": _REDACTED, "user": "x"}
+
+    def test_case_insensitive(self) -> None:
+        """Header-style mixed-case keys are matched case-insensitively."""
+        out = _redact_mapping({"Authorization": "Bearer eyJ..."}, _REDACT_HEADER_KEYS)
+        assert out == {"Authorization": _REDACTED}
+
+    def test_nested_dict_recursed(self) -> None:
+        """Nested mappings are walked and redacted in place."""
+        out = _redact_mapping(
+            {"outer": {"refresh_token": "v0.x", "ok": True}},
+            _REDACT_BODY_KEYS,
+        )
+        assert out == {"outer": {"refresh_token": _REDACTED, "ok": True}}
+
+    def test_list_of_mappings_walked(self) -> None:
+        """Lists of dicts are walked element-wise."""
+        out = _redact_mapping(
+            {"items": [{"otp": "123456"}, {"otp": "654321"}]},
+            _REDACT_BODY_KEYS,
+        )
+        assert out == {"items": [{"otp": _REDACTED}, {"otp": _REDACTED}]}
+
+    def test_non_mapping_returns_empty(self) -> None:
+        """Non-mapping inputs degrade to ``{}`` rather than raising."""
+        assert _redact_mapping("not a mapping", _REDACT_BODY_KEYS) == {}  # type: ignore[arg-type]
+
+    def test_partial_mask_string_keeps_tail(self) -> None:
+        """PII keys are partially masked, preserving last 4 chars."""
+        out = _redact_mapping(
+            {"ean": "541448820000010001", "other": "x"},
+            _REDACT_BODY_KEYS,
+            _PARTIAL_MASK_BODY_KEYS,
+        )
+        assert out == {"ean": f"{_REDACTED}0001", "other": "x"}
+
+    def test_partial_mask_case_insensitive(self) -> None:
+        """PII key matching is case-insensitive (matches camelCase API keys)."""
+        out = _redact_mapping(
+            {"customerAccountNumber": "1234567890", "ok": True},
+            _REDACT_BODY_KEYS,
+            _PARTIAL_MASK_BODY_KEYS,
+        )
+        assert out == {"customerAccountNumber": f"{_REDACTED}7890", "ok": True}
+
+    def test_partial_mask_numeric_value(self) -> None:
+        """Numeric PII values are stringified then partially masked."""
+        out = _redact_mapping(
+            {"customerAccountNumber": 1234567890},
+            _REDACT_BODY_KEYS,
+            _PARTIAL_MASK_BODY_KEYS,
+        )
+        assert out == {"customerAccountNumber": f"{_REDACTED}7890"}
+
+    def test_partial_mask_recurses_into_nested_pii(self) -> None:
+        """A PII key holding a dict (e.g. address) recurses, not collapses."""
+        out = _redact_mapping(
+            {
+                "address": {
+                    "street": "Rue de la Loi",
+                    "city": "Brussels",
+                    "houseNumber": "200",
+                }
+            },
+            _REDACT_BODY_KEYS,
+            _PARTIAL_MASK_BODY_KEYS,
+        )
+        # ``address`` itself is not in the partial set, but its children are.
+        assert out == {
+            "address": {
+                "street": f"{_REDACTED} Loi",
+                "city": f"{_REDACTED}sels",
+                "houseNumber": f"{_REDACTED}",  # 3-char value -> fully masked
+            }
+        }
+
+    def test_full_mask_takes_precedence_over_partial(self) -> None:
+        """A key in both sets is fully masked (credentials win over PII)."""
+        # Construct an artificial overlap to assert the precedence rule.
+        out = _redact_mapping(
+            {"password": "long-secret-value", "ean": "9999"},
+            _REDACT_BODY_KEYS,
+            _PARTIAL_MASK_BODY_KEYS | {"password"},
+        )
+        assert out["password"] == _REDACTED
+        # Short value (<= 4 chars) in partial set still collapses to ``***``.
+        assert out["ean"] == _REDACTED
+
+    def test_partial_mask_in_list_of_strings(self) -> None:
+        """Lists of PII strings under a partial-mask key are walked."""
+        out = _redact_mapping(
+            {"email": ["a@example.com", "bb@example.com"]},
+            _REDACT_BODY_KEYS,
+            _PARTIAL_MASK_BODY_KEYS,
+        )
+        assert out == {
+            "email": [f"{_REDACTED}.com", f"{_REDACTED}.com"],
+        }
+
+
+class TestRedactUrl:
+    """``_redact_url`` only rewrites the query string."""
+
+    def test_no_query_passthrough(self) -> None:
+        """URLs without a query string are returned unchanged."""
+        url = "https://api.engie.be/v1/foo"
+        assert _redact_url(url) == url
+
+    def test_query_redacted(self) -> None:
+        """Sensitive query params get ``***`` (URL-encoded)."""
+        url = "https://auth.engie.be/authorize?state=secret-state&ui_locales=nl"
+        out = _redact_url(url)
+        assert "secret-state" not in out
+        assert "state=%2A%2A%2A" in out  # _REDACTED url-encoded
+        assert "ui_locales=nl" in out
+
+    def test_path_and_host_preserved(self) -> None:
+        """Host and path survive verbatim; only the query is rewritten."""
+        url = (
+            "https://auth.engie.be/u/login/identifier?state=abc&code=xyz&ui_locales=nl"
+        )
+        out = _redact_url(url)
+        assert out.startswith("https://auth.engie.be/u/login/identifier")
+        assert "abc" not in out
+        assert "xyz" not in out
+
+    def test_unknown_query_keys_kept(self) -> None:
+        """Non-sensitive query params (e.g. ``maxGranularity``) are untouched."""
+        url = "https://api.engie.be/v1/foo?maxGranularity=MONTHLY"
+        assert _redact_url(url) == url
+
+
+class TestRedactBody:
+    """``_redact_body`` handles JSON, form, HTML, and plain text shapes."""
+
+    def test_empty_renders_placeholder(self) -> None:
+        """Empty / ``None`` bodies render as ``<empty>``."""
+        assert _redact_body(None, None) == "<empty>"
+        assert _redact_body("", None) == "<empty>"
+        assert _redact_body(b"", None) == "<empty>"
+
+    def test_dict_input_serialised_and_redacted(self) -> None:
+        """Dict input is JSON-serialised with credential keys masked."""
+        out = _redact_body({"refresh_token": "v0.x", "ok": True}, "application/json")
+        parsed = json.loads(out)
+        assert parsed == {"refresh_token": _REDACTED, "ok": True}
+
+    def test_json_string_parsed_and_redacted(self) -> None:
+        """JSON-string bodies are reparsed, redacted, and re-serialised."""
+        body = json.dumps({"access_token": "eyJ...", "scope": "openid"})
+        out = _redact_body(body, "application/json")
+        parsed = json.loads(out)
+        assert parsed == {"access_token": _REDACTED, "scope": "openid"}
+
+    def test_form_urlencoded_redacted(self) -> None:
+        """Form-encoded bodies have credential fields masked in place."""
+        body = "refresh_token=v0.secret&grant_type=refresh_token&client_id=cid"
+        out = _redact_body(body, "application/x-www-form-urlencoded")
+        assert "v0.secret" not in out
+        assert "refresh_token=%2A%2A%2A" in out
+        assert "grant_type=refresh_token" in out
+        assert "client_id=cid" in out
+
+    def test_html_truncated_and_summarised(self) -> None:
+        """HTML bodies are summarised to a length + short preview."""
+        big = "<!DOCTYPE html><html>" + ("a" * 5000) + "</html>"
+        out = _redact_body(big, "text/html; charset=utf-8")
+        assert out.startswith("<html len=")
+        # The ``preview=...`` repr of a 120-char window plus framing.
+        assert "preview=" in out
+        # Crude upper bound: framing + 120-char preview + repr quotes.
+        assert len(out) < _HTML_PREVIEW_MAX + 80
+
+    def test_html_detected_by_shape_when_ct_missing(self) -> None:
+        """Bodies starting with ``<html`` are summarised even without a CT."""
+        out = _redact_body("<html><body>hi</body></html>", None)
+        assert out.startswith("<html len=")
+
+    def test_bytes_decoded_then_redacted(self) -> None:
+        """``bytes`` input is decoded as UTF-8 before redaction."""
+        body = json.dumps({"password": "x"}).encode("utf-8")
+        out = _redact_body(body, "application/json")
+        parsed = json.loads(out)
+        assert parsed == {"password": _REDACTED}
+
+    def test_plain_text_passthrough(self) -> None:
+        """Plain-text bodies are returned verbatim."""
+        out = _redact_body("plain status text", "text/plain")
+        assert out == "plain status text"
+
+    def test_invalid_json_string_passes_through(self) -> None:
+        """Malformed JSON returns the raw string rather than raising."""
+        out = _redact_body("not really json {{{", "application/json")
+        assert out == "not really json {{{"
+
+    def test_relations_response_pii_partially_masked(self) -> None:
+        """ENGIE relations payload: PII keys are partial-masked end-to-end."""
+        # Mirrors the shape of ``customer_account_relations_sample.json``
+        # well enough to lock the contract that no full PII value reaches
+        # the log line.
+        body = json.dumps(
+            {
+                "customerAccountNumber": "1234567890",
+                "name": "Jane Doe",
+                "emailAddress": "jane.doe@example.com",
+                "premises": [
+                    {
+                        "premisesNumber": "PR-99887766",
+                        "address": {
+                            "street": "Rue de la Loi",
+                            "houseNumber": "200",
+                            "postalCode": "1000",
+                            "city": "Brussels",
+                        },
+                        "ean": "541448820000010001",
+                    }
+                ],
+            }
+        )
+        out = _redact_body(body, "application/json")
+        # Hard contract: no raw PII value appears in the logged string.
+        assert "1234567890" not in out
+        assert "Jane Doe" not in out
+        assert "jane.doe@example.com" not in out
+        assert "PR-99887766" not in out
+        assert "Rue de la Loi" not in out
+        assert "Brussels" not in out
+        assert "541448820000010001" not in out
+        # And the masked tails are present (greppability invariant).
+        parsed = json.loads(out)
+        assert parsed["customerAccountNumber"] == f"{_REDACTED}7890"
+        assert parsed["emailAddress"].endswith(".com")
+        assert parsed["premises"][0]["ean"] == f"{_REDACTED}0001"
+        assert parsed["premises"][0]["address"]["city"] == f"{_REDACTED}sels"
+
+
+# ---------------------------------------------------------------------------
+# E2E: ``_api_wrapper`` (via ``async_refresh_token``)
+# ---------------------------------------------------------------------------
+
+
+def _make_session(response: MagicMock) -> MagicMock:
+    """Build a stub ``aiohttp.ClientSession`` whose request returns *response*."""
+    session = MagicMock()
+    session.request = AsyncMock(return_value=response)
+    return session
+
+
+def _make_response(
+    *,
+    status: int,
+    json_body: Any | None = None,
+    text_body: str | None = None,
+    content_type: str = "application/json",
+) -> MagicMock:
+    """Stub aiohttp response usable by both ``.json()`` and ``.text()``."""
+    response = MagicMock()
+    response.status = status
+    response.headers = {"Content-Type": content_type}
+    if json_body is not None:
+        response.json = AsyncMock(return_value=json_body)
+        response.text = AsyncMock(return_value=json.dumps(json_body))
+    else:
+        response.json = AsyncMock(return_value=None)
+        response.text = AsyncMock(return_value=text_body or "")
+    response.raise_for_status = MagicMock()
+    return response
+
+
+def _arrows_for(records: list[logging.LogRecord]) -> list[str]:
+    """Return the rendered messages, dropping non-arrow noise."""
+    return [
+        r.getMessage() for r in records if r.getMessage().startswith(("→", "←", "✗"))
+    ]
+
+
+def _extract_req_id(message: str) -> str | None:
+    match = re.search(r"req_id=([0-9a-f]+)", message)
+    return match.group(1) if match else None
+
+
+async def test_api_wrapper_logs_request_and_response_with_correlated_req_id(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A successful request emits a paired → / ← with the same req_id."""
+    response = _make_response(
+        status=200,
+        json_body={
+            "access_token": "eyJabc.def",
+            "refresh_token": "v0.new",
+            "expires_in": 120,
+        },
+    )
+    session = _make_session(response)
+    client = EngieBeApiClient(
+        session=session,
+        client_id="client-1",
+        refresh_token="v0.original",  # noqa: S106
+    )
+
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+        await client.async_refresh_token()
+
+    arrows = _arrows_for(caplog.records)
+    # At least one → and one ← (refresh_token call).  Refresh-token
+    # rotation breadcrumb is separate and not arrow-prefixed.
+    request_lines = [m for m in arrows if m.startswith("→")]
+    response_lines = [m for m in arrows if m.startswith("←")]
+    assert request_lines, "expected at least one '→' debug line"
+    assert response_lines, "expected at least one '←' debug line"
+
+    req_id = _extract_req_id(request_lines[0])
+    resp_id = _extract_req_id(response_lines[0])
+    assert req_id is not None
+    assert req_id == resp_id, "→ and ← lines must share the same req_id"
+
+
+async def test_api_wrapper_redacts_secrets_in_request_and_response(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tokens, passwords, and OAuth state are masked in DEBUG logs."""
+    response = _make_response(
+        status=200,
+        json_body={"access_token": "eyJSECRETabc", "refresh_token": "v0.SECRETnew"},
+    )
+    session = _make_session(response)
+    client = EngieBeApiClient(
+        session=session,
+        client_id="client-1",
+        refresh_token="v0.SECRETold",  # noqa: S106
+    )
+
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+        await client.async_refresh_token()
+
+    blob = "\n".join(r.getMessage() for r in caplog.records)
+    # Refresh-token bodies + OAuth response tokens are all masked.
+    assert "v0.SECRETold" not in blob
+    assert "v0.SECRETnew" not in blob
+    assert "eyJSECRETabc" not in blob
+    # The rotation breadcrumb leaks only the redacted tail.
+    assert "Token refresh: rotated refresh_token" in blob
+
+
+async def test_api_wrapper_status_and_timing_present(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The ← line carries status and a millisecond timing field."""
+    response = _make_response(
+        status=200, json_body={"access_token": "a", "refresh_token": "b"}
+    )
+    session = _make_session(response)
+    client = EngieBeApiClient(
+        session=session,
+        client_id="client-1",
+        refresh_token="v0.x",  # noqa: S106
+    )
+
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+        await client.async_refresh_token()
+
+    response_lines = [m for m in _arrows_for(caplog.records) if m.startswith("←")]
+    assert response_lines
+    line = response_lines[0]
+    assert "status=200" in line
+    assert re.search(r"in \d+ms", line), f"missing timing in {line!r}"
+
+
+async def test_api_wrapper_logs_failure_on_5xx(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A 5xx response logs a ✗ line with status + timing and raises."""
+    response = _make_response(
+        status=503, text_body="Service Unavailable", content_type="text/plain"
+    )
+    response.raise_for_status = MagicMock(
+        side_effect=aiohttp.ClientResponseError(
+            request_info=MagicMock(), history=(), status=503
+        )
+    )
+    session = _make_session(response)
+    client = EngieBeApiClient(
+        session=session,
+        client_id="client-1",
+        refresh_token="v0.x",  # noqa: S106
+    )
+
+    with (
+        caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME),
+        pytest.raises(EngieBeApiClientCommunicationError),
+    ):
+        await client.async_refresh_token()
+
+    error_lines = [m for m in _arrows_for(caplog.records) if m.startswith("✗")]
+    assert error_lines, "expected a ✗ debug line on 5xx"
+    assert "status=503" in error_lines[0]
+    assert re.search(r"in \d+ms", error_lines[0])
+
+
+async def test_api_wrapper_no_debug_lines_when_level_off(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """With DEBUG disabled, no arrow log lines are emitted."""
+    response = _make_response(
+        status=200, json_body={"access_token": "a", "refresh_token": "b"}
+    )
+    session = _make_session(response)
+    client = EngieBeApiClient(
+        session=session,
+        client_id="client-1",
+        refresh_token="v0.x",  # noqa: S106
+    )
+
+    # WARNING is well above DEBUG -- redaction-gated branches must short-circuit.
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        await client.async_refresh_token()
+
+    assert _arrows_for(caplog.records) == []
+
+
+async def test_api_wrapper_unexpected_exception_logs_with_exc_info(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    The bare-``Exception`` branch in ``_api_wrapper`` attaches a stack trace.
+
+    Triggers an unexpected exception type (``RuntimeError``) from
+    ``session.request`` so the catch-all branch fires; asserts the
+    emitted DEBUG record carries ``exc_info`` (i.e. a traceback is
+    rendered for operator debugging).
+    """
+    session = MagicMock()
+    session.request = AsyncMock(side_effect=RuntimeError("kaboom"))
+    client = EngieBeApiClient(
+        session=session,
+        client_id="client-1",
+        refresh_token="v0.x",  # noqa: S106
+    )
+
+    with (
+        caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME),
+        pytest.raises(Exception, match="Unexpected error communicating"),
+    ):
+        await client.async_refresh_token()
+
+    error_records = [
+        r
+        for r in caplog.records
+        if r.getMessage().startswith("✗") and "RuntimeError" in r.getMessage()
+    ]
+    assert error_records, "expected ✗ DEBUG record for the unexpected branch"
+    assert error_records[0].exc_info is not None, (
+        "bare-Exception branch must pass exc_info=True so the traceback is logged"
+    )
+
+
+# ---------------------------------------------------------------------------
+# E2E: EPEX inline path
+# ---------------------------------------------------------------------------
+
+
+_EPEX_FROM = datetime(2026, 5, 4, 0, 0, 0, tzinfo=UTC)
+_EPEX_TO = datetime(2026, 5, 5, 0, 0, 0, tzinfo=UTC)
+
+
+async def test_epex_logs_paired_request_response(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """EPEX happy path emits its own → / ← pair with shared req_id."""
+    payload = {"timeSeries": [{"start": "x", "value": 1.23}]}
+    response = _make_response(status=200, json_body=payload)
+    session = _make_session(response)
+    client = EngieBeApiClient(session=session, client_id="c", access_token="t")  # noqa: S106
+
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+        result = await client.async_get_epex_prices(_EPEX_FROM, _EPEX_TO)
+
+    assert result == payload
+    arrows = _arrows_for(caplog.records)
+    request_lines = [m for m in arrows if m.startswith("→")]
+    response_lines = [m for m in arrows if m.startswith("←")]
+    assert request_lines
+    assert response_lines
+    assert _extract_req_id(request_lines[0]) == _extract_req_id(response_lines[0])
+
+
+async def test_epex_404_logs_failure_and_raises_not_published(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """404 logs a ✗ line and raises ``EpexNotPublishedError``."""
+    response = _make_response(
+        status=404,
+        text_body='{"detail":"No prices found"}',
+        content_type="application/problem+json",
+    )
+    session = _make_session(response)
+    client = EngieBeApiClient(session=session, client_id="c", access_token="t")  # noqa: S106
+
+    with (
+        caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME),
+        pytest.raises(EpexNotPublishedError),
+    ):
+        await client.async_get_epex_prices(_EPEX_FROM, _EPEX_TO)
+
+    error_lines = [m for m in _arrows_for(caplog.records) if m.startswith("✗")]
+    assert error_lines
+    assert "status=404" in error_lines[0]
+
+
+async def test_epex_500_logs_failure_and_raises_communication_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """5xx on EPEX logs a ✗ line and raises a communication error."""
+    response = _make_response(
+        status=500,
+        text_body="boom",
+        content_type="text/plain",
+    )
+    session = _make_session(response)
+    client = EngieBeApiClient(session=session, client_id="c", access_token="t")  # noqa: S106
+
+    with (
+        caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME),
+        pytest.raises(EngieBeApiClientCommunicationError),
+    ):
+        await client.async_get_epex_prices(_EPEX_FROM, _EPEX_TO)
+
+    error_lines = [m for m in _arrows_for(caplog.records) if m.startswith("✗")]
+    assert error_lines
+    assert "status=500" in error_lines[0]
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting: no token/cookie/password leaks anywhere
+# ---------------------------------------------------------------------------
+
+
+async def test_authorization_header_redacted_in_logs(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    ``authorization: Bearer ...`` headers must be masked in → lines.
+
+    Uses ``async_get_prices`` (an authenticated endpoint that sends a
+    ``Bearer`` header through ``_api_wrapper``) rather than EPEX, which
+    is unauthenticated.
+    """
+    response = _make_response(status=200, json_body={"items": []})
+    session = _make_session(response)
+    client = EngieBeApiClient(
+        session=session,
+        client_id="c",
+        access_token="eyJSUPER_SECRET_BEARER_TOKEN",  # noqa: S106
+    )
+
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+        await client.async_get_prices("123456789012")
+
+    blob = "\n".join(r.getMessage() for r in caplog.records)
+    assert "eyJSUPER_SECRET_BEARER_TOKEN" not in blob
+    # The header key is preserved (so logs remain greppable) but value masked.
+    assert "authorization" in blob.lower()
+    assert _REDACTED in blob


### PR DESCRIPTION
## Summary
Adds structured DEBUG-level request/response logging across the ENGIE Belgium API client, with aggressive redaction of credentials and PII. Helps diagnose API behavior in user logs without leaking tokens, EANs, customer IDs, or emails.

## Scope
`custom_components/engie_be/api.py` only. No coordinator, sensor, binary_sensor, config_flow, or storage changes.

## Changes
- New `_log_request` / `_log_response` / `_log_error` helpers shared by `_api_wrapper` and the EPEX inline path. Single source of truth for the `→` / `←` / `✗` log format.
- 8-char `req_id` (`uuid4().hex[:8]`) correlates request, response, and error lines for a given call. Only generated when DEBUG is enabled.
- Redaction:
  - Tokens fully masked: `authorization`, `access_token`, `refresh_token`, `id_token`, OAuth `state`/`code`/`code_verifier`/`code_challenge`/`nonce`, `password`, MFA `code`.
  - PII partial-masked (last 4 chars preserved): emails, EAN, customer/business-agreement numbers, postal addresses.
  - HTML responses truncated to 120-char preview; JSON/form bodies logged in full.
- Refresh-token rotation breadcrumb logged on every successful refresh — makes ENGIE's per-call rotation visible in logs.
- `_log_error` covers all five `✗` variants (HTTP error, timeout, ClientError, EPEX-404 with suffix, bare `Exception` with `exc_info=True`).

## Tests
- 39 new tests in `tests/test_api_logging.py` covering redaction primitives, request/response/error helpers, and end-to-end smoke through `_api_wrapper` and the EPEX path.
- Full suite: 328 passed, coverage ~86% (gate: 85%).

## Smoke test
Live dev HA setup of a fresh integration confirms:
- Auth steps 1–13 logged with redaction intact.
- Token rotation breadcrumb visible.
- All entity registrations + renames complete cleanly.
- EPEX, supplier prices, peaks, service-points, energy-contracts all `200`.

## Out of scope
- Audit Findings 4 (`repr` body cap), 7 (req_id collision risk), 8 (form sniff heuristic) deferred — see `.opencode/audit-debug-logging.md`.
- A pre-existing 404-tears-down-entry issue surfaced during smoke testing is tracked separately.