### PR TITLE
chore(sensor): hoist EpexPayload import, drop PLC0415 noqa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Internal
+- Hoisted the deferred `EpexPayload` import in `sensor.py:_epex_payload`
+  to the module-level imports and dropped the unjustified
+  `# noqa: PLC0415`. `data.py` has no runtime imports of any sibling
+  module (everything is `TYPE_CHECKING`-gated), so the local import
+  was not load-bearing. Audit hygiene only; no runtime behaviour
+  change.
+
 ### Changed
 - **Structured DEBUG-level request/response logging** in the ENGIE
   Belgium API client. Each HTTP call is bracketed with paired `→` /

--- a/custom_components/engie_be/sensor.py
+++ b/custom_components/engie_be/sensor.py
@@ -22,6 +22,7 @@ from .const import (
     LOGGER,
     SUBENTRY_TYPE_CUSTOMER_ACCOUNT,
 )
+from .data import EpexPayload
 from .entity import EngieBeEntity, EngieBeEpexEntity
 
 # Coordinator centralises updates; entities never poll individually.
@@ -33,7 +34,7 @@ if TYPE_CHECKING:
     from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
     from .coordinator import EngieBeDataUpdateCoordinator, EngieBeEpexCoordinator
-    from .data import EngieBeConfigEntry, EpexPayload
+    from .data import EngieBeConfigEntry
 
 
 # Mapping from service-point division to display name.
@@ -594,10 +595,8 @@ def _build_epex_sensors(
 
 def _epex_payload(coordinator: EngieBeEpexCoordinator) -> EpexPayload | None:
     """Return the cached EPEX payload, or ``None`` if not yet fetched."""
-    from .data import EpexPayload as _EpexPayload  # noqa: PLC0415
-
     payload = coordinator.data
-    return payload if isinstance(payload, _EpexPayload) else None
+    return payload if isinstance(payload, EpexPayload) else None
 
 
 def _slots_for_date(payload: EpexPayload, target: date) -> list[Any]:


### PR DESCRIPTION
## Summary
- Hoist `from .data import EpexPayload` in `sensor.py` to the module-level imports.
- Drop the unjustified `# noqa: PLC0415` from the local re-import inside `_epex_payload`.

## Why
Ruff `PLC0415` (`import-outside-top-level`) was suppressed without a rationale comment at `sensor.py:597`. Per `AGENTS.md`:
> Justify any `# noqa` narrowly.

Inspection showed `data.py` has zero runtime imports of any sibling module — every cross-module import is `TYPE_CHECKING`-gated. The local deferred import was therefore not load-bearing and could simply be hoisted, which is cleaner than adding a rationale comment for a non-existent cycle.

## Verification
- `ruff check custom_components/ tests/` — pass
- `ruff format --check custom_components/ tests/` — pass
- `pytest --cov=custom_components.engie_be --cov-fail-under=85` — 330 passed, coverage 85.68% (sensor.py still 87%)

## Notes
- Audit hygiene only; no runtime behaviour change.
- No version bump (intentional — batched into the existing `[Unreleased]` block).
- No user-visible changes; `README.md` / `strings.json` untouched.