### PR TITLE
fix(entity): instant-flip Happy Hour and EPEX boundary entities (#25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Fixed
+
+- **Happy Hour active binary sensor now flips at the second.** The
+  `binary_sensor.*_happy_hour_active` entity previously only updated
+  when the coordinator next refreshed, which meant the on/off
+  transition could lag by up to a full refresh interval. The sensor
+  now schedules a precise point-in-time callback at the start and
+  end of each window, mirroring the pattern used by Home Assistant's
+  built-in Time of Day helper. Automations that key off this sensor
+  (for example, to start an EV charger or run the dishwasher) now
+  see the transition within a second of the window boundary.
+  ([#25][])
+- **EPEX negative-price binary sensor now flips at the slot
+  boundary.** The `binary_sensor.*_epex_negative_now` entity used the
+  same coordinator-refresh cadence as the Happy Hour sensor and could
+  lag by up to an hour at the top of each market slot. It now uses the
+  same point-in-time scheduler, so the on/off transition lines up with
+  the exact second the EPEX market moves to the next hourly slot.
+- **EPEX current-price and next-hour sensors now roll at the slot
+  boundary.** `sensor.*_epex_current` and `sensor.*_epex_next_hour`
+  share the same scheduler and now publish the new slot's price the
+  instant the market rolls over, instead of waiting for the next
+  coordinator refresh. Dashboards and price-driven automations no
+  longer need a tight refresh interval to track hourly transitions.
+
+[#25]: https://github.com/DaanVervacke/hass-engie-be/issues/25
+
 ## [0.10.0b1] - 2026-05-22
 
 > [!CAUTION]

--- a/custom_components/engie_be/_epex.py
+++ b/custom_components/engie_be/_epex.py
@@ -1,0 +1,51 @@
+"""
+Pure helpers for EPEX slot-boundary scheduling.
+
+Kept dependency-free so the slot-boundary computation can be unit
+tested in isolation and reused across the binary-sensor and sensor
+platforms without crossing entity-class boundaries.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from .data import EpexPayload
+
+
+def next_epex_slot_boundary(
+    payload: EpexPayload | None,
+    now: datetime,
+) -> datetime | None:
+    """
+    Return the next UTC instant at which the current EPEX slot changes.
+
+    The returned datetime is the earliest of:
+
+    * ``slot.end`` for the slot covering ``now`` (when one exists), and
+    * ``slot.start`` for the earliest slot whose start is strictly
+      greater than ``now``.
+
+    Returns ``None`` when the payload is ``None``, when the payload
+    has no slots, or when every slot is entirely in the past.
+
+    The function does not assume contiguity: gaps between slots are
+    handled correctly by considering both the current-slot end and
+    the next-slot start as independent candidates.
+    """
+    if payload is None or not payload.slots:
+        return None
+
+    candidates: list[datetime] = []
+    for slot in payload.slots:
+        if slot.start <= now < slot.end:
+            candidates.append(slot.end)
+        elif slot.start > now:
+            candidates.append(slot.start)
+
+    if not candidates:
+        return None
+    return min(candidates)

--- a/custom_components/engie_be/binary_sensor.py
+++ b/custom_components/engie_be/binary_sensor.py
@@ -12,7 +12,8 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.const import EntityCategory
 from homeassistant.util import dt as dt_util
 
-from ._happy_hour import is_happy_hour_active
+from ._epex import next_epex_slot_boundary
+from ._happy_hour import happy_hour_window, is_happy_hour_active
 from .api import mask_identifier
 from .const import (
     CONF_BUSINESS_AGREEMENT_NUMBER,
@@ -20,12 +21,19 @@ from .const import (
     SUBENTRY_TYPE_BUSINESS_AGREEMENT,
 )
 from .data import EpexPayload
-from .entity import EngieBeAuthEntity, EngieBeEntity, EngieBeEpexEntity
+from .entity import (
+    EngieBeAuthEntity,
+    EngieBeEntity,
+    EngieBeEpexEntity,
+    _BoundaryScheduleMixin,
+)
 
 # Coordinator centralises updates; entities never poll individually.
 PARALLEL_UPDATES = 0
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     from homeassistant.config_entries import ConfigSubentry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -193,7 +201,9 @@ def _epex_payload(coordinator: EngieBeEpexCoordinator) -> EpexPayload | None:
     return payload if isinstance(payload, EpexPayload) else None
 
 
-class EngieBeEpexNegativeSensor(EngieBeEpexEntity, BinarySensorEntity):
+class EngieBeEpexNegativeSensor(
+    _BoundaryScheduleMixin, EngieBeEpexEntity, BinarySensorEntity
+):
     """
     Binary sensor that turns ``on`` when the current EPEX slot is negative.
 
@@ -216,6 +226,11 @@ class EngieBeEpexNegativeSensor(EngieBeEpexEntity, BinarySensorEntity):
       the account silently flipped off the dynamic tariff between
       polls without a config-entry reload (defensive only; the entity
       isn't created at all on accounts that are non-dynamic at setup).
+
+    The ``_BoundaryScheduleMixin`` arms a point-in-UTC-time callback at
+    the next slot boundary so the entity flips at the exact second the
+    market moves between negative and non-negative slots, rather than
+    waiting up to a full coordinator refresh interval.
     """
 
     entity_description = EPEX_NEGATIVE_SENSOR_DESCRIPTION
@@ -275,8 +290,25 @@ class EngieBeEpexNegativeSensor(EngieBeEpexEntity, BinarySensorEntity):
                 return slot.value_eur_per_kwh < 0
         return None
 
+    def _next_boundary(self) -> datetime | None:
+        """
+        Return the next EPEX slot boundary in UTC, or ``None``.
 
-class EngieBeHappyHourActiveSensor(EngieBeEntity, BinarySensorEntity):
+        Delegates to :func:`next_epex_slot_boundary` so the helper is
+        shared with the EPEX current-price and next-hour sensors. When
+        the cached payload is fully in the past (multi-hour outage),
+        returns ``None``; the next coordinator update re-arms via
+        :meth:`_handle_coordinator_update` once a fresh payload lands.
+        """
+        payload = _epex_payload(self.coordinator)
+        if payload is None:
+            return None
+        return next_epex_slot_boundary(payload, dt_util.utcnow())
+
+
+class EngieBeHappyHourActiveSensor(
+    _BoundaryScheduleMixin, EngieBeEntity, BinarySensorEntity
+):
     """
     Binary sensor that turns ``on`` during a scheduled Happy Hour window.
 
@@ -296,6 +328,11 @@ class EngieBeHappyHourActiveSensor(EngieBeEntity, BinarySensorEntity):
     consult the ``happy_hour_next_start`` / ``happy_hour_next_end``
     timestamp sensors (which are ``unknown`` when no window is
     scheduled).
+
+    The ``_BoundaryScheduleMixin`` arms a point-in-UTC-time callback
+    at the next window boundary so the entity flips on and off at the
+    exact second the window starts and ends, rather than waiting up to
+    a full coordinator refresh interval.
     """
 
     entity_description = HAPPY_HOUR_ACTIVE_SENSOR_DESCRIPTION
@@ -319,3 +356,23 @@ class EngieBeHappyHourActiveSensor(EngieBeEntity, BinarySensorEntity):
     def is_on(self) -> bool:
         """Return True iff the current moment is inside a scheduled window."""
         return is_happy_hour_active(self.coordinator, dt_util.utcnow())
+
+    def _next_boundary(self) -> datetime | None:
+        """
+        Return the next happy-hour boundary in UTC, or ``None``.
+
+        Picks ``start`` while the window is still in the future, ``end``
+        while we are inside it, and ``None`` once both endpoints are in
+        the past (the next coordinator refresh either replaces the
+        cached payload with the next day's window or with ``{}``).
+        """
+        window = happy_hour_window(self.coordinator)
+        if window is None:
+            return None
+        start, end = window
+        now = dt_util.utcnow()
+        if now < start:
+            return start
+        if now < end:
+            return end
+        return None

--- a/custom_components/engie_be/entity.py
+++ b/custom_components/engie_be/entity.py
@@ -5,16 +5,126 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from homeassistant.const import CONF_USERNAME
+from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
 
 from .const import ATTRIBUTION, DOMAIN
 from .coordinator import EngieBeDataUpdateCoordinator, EngieBeEpexCoordinator
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+    from datetime import datetime
+
     from homeassistant.config_entries import ConfigSubentry
 
     from .data import EngieBeConfigEntry
+
+
+class _BoundaryScheduleMixin:
+    """
+    Mixin that re-evaluates entity state at the next "boundary" instant.
+
+    Many ENGIE entities (Happy Hour active, EPEX-negative, EPEX
+    current-price, EPEX next-hour) derive their state from a time
+    window plus the current instant. Without help, they only refresh
+    when their coordinator does, which can be up to a full refresh
+    interval (default 60 minutes) late. This mixin schedules a single
+    point-in-UTC-time callback at the next state-change instant and
+    re-arms itself on fire, mirroring the pattern used by Home
+    Assistant core's ``binary_sensor.tod`` integration.
+
+    Concrete subclasses supply ``_next_boundary`` to describe when the
+    next state change will occur. Returning ``None`` means "no future
+    boundary is known yet" and arms no timer; the next coordinator
+    update is expected to call ``_handle_coordinator_update`` and
+    recompute.
+
+    MRO requirement: this mixin MUST come before the entity's
+    coordinator base (``EngieBeEntity``, ``EngieBeEpexEntity``, etc.)
+    so that ``async_added_to_hass`` and ``_handle_coordinator_update``
+    chain through ``super()`` to the ``CoordinatorEntity``
+    implementation.
+    """
+
+    _unsub_boundary: Callable[[], None] | None = None
+
+    def _next_boundary(self) -> datetime | None:
+        """
+        Return the next UTC datetime at which this entity's state changes.
+
+        Subclasses must override. Returning ``None`` skips arming the
+        timer (e.g. payload not yet available, or every relevant
+        window already in the past).
+        """
+        msg = (
+            f"{type(self).__name__} must override _next_boundary to use "
+            "_BoundaryScheduleMixin"
+        )
+        raise NotImplementedError(msg)
+
+    async def async_added_to_hass(self) -> None:
+        """Arm the next-boundary timer when the entity joins HA."""
+        await super().async_added_to_hass()  # type: ignore[misc]
+        self.async_on_remove(self._cancel_boundary)  # type: ignore[attr-defined]
+        self._schedule_next_boundary()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """
+        Re-arm the boundary timer whenever the coordinator data changes.
+
+        Cancels any pending timer, recomputes the next boundary against
+        the freshly-published payload, and only then chains to the
+        ``CoordinatorEntity`` implementation which performs the state
+        write.
+        """
+        self._cancel_boundary()
+        self._schedule_next_boundary()
+        super()._handle_coordinator_update()  # type: ignore[misc]
+
+    @callback
+    def _cancel_boundary(self) -> None:
+        """Cancel any pending boundary timer and clear the handle."""
+        if self._unsub_boundary is not None:
+            self._unsub_boundary()
+            self._unsub_boundary = None
+
+    @callback
+    def _schedule_next_boundary(self) -> None:
+        """
+        Compute the next boundary and arm a point-in-UTC-time callback.
+
+        No-op when ``_next_boundary`` returns ``None`` or returns a
+        timestamp not strictly in the future (defensive: handles the
+        case where the boundary helper races against ``dt_util.utcnow``
+        and returns a value that has already elapsed).
+        """
+        target = self._next_boundary()
+        if target is None or target <= dt_util.utcnow():
+            return
+        self._unsub_boundary = async_track_point_in_utc_time(
+            self.hass,  # type: ignore[attr-defined]
+            self._boundary_fired,
+            target,
+        )
+
+    @callback
+    def _boundary_fired(self, _now: datetime) -> None:
+        """
+        Re-arm for the boundary after this one and write fresh state.
+
+        The HA scheduler delivers the current time as the callback's
+        argument; we discard it because every consumer in this
+        codebase reads ``dt_util.utcnow`` directly. Clearing
+        ``_unsub_boundary`` first ensures the handle does not outlive
+        the timer that has just fired.
+        """
+        self._unsub_boundary = None
+        self._schedule_next_boundary()
+        self.async_write_ha_state()  # type: ignore[attr-defined]
 
 
 class _EngieBeBaseEntity:

--- a/custom_components/engie_be/manifest.json
+++ b/custom_components/engie_be/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.engie_be"
   ],
   "quality_scale": "bronze",
-  "version": "0.10.0b1"
+  "version": "0.10.0b2"
 }

--- a/custom_components/engie_be/sensor.py
+++ b/custom_components/engie_be/sensor.py
@@ -15,6 +15,7 @@ from homeassistant.components.sensor import (
 from homeassistant.const import UnitOfEnergy, UnitOfPower
 from homeassistant.util import dt as dt_util
 
+from ._epex import next_epex_slot_boundary
 from ._happy_hour import happy_hour_window
 from ._peaks import peaks_meta, peaks_payload
 from .api import mask_identifier
@@ -25,7 +26,7 @@ from .const import (
     SUBENTRY_TYPE_BUSINESS_AGREEMENT,
 )
 from .data import EpexPayload
-from .entity import EngieBeEntity, EngieBeEpexEntity
+from .entity import EngieBeEntity, EngieBeEpexEntity, _BoundaryScheduleMixin
 
 # Coordinator centralises updates; entities never poll individually.
 PARALLEL_UPDATES = 0
@@ -701,8 +702,18 @@ def _slots_for_date(payload: EpexPayload, target: date) -> list[Any]:
     return [slot for slot in payload.slots if slot.start.date() == target]
 
 
-class _EngieBeEpexSensorBase(EngieBeEpexEntity, SensorEntity):
-    """Common base for EPEX day-ahead sensors."""
+class _EngieBeEpexSensorBase(_BoundaryScheduleMixin, EngieBeEpexEntity, SensorEntity):
+    """
+    Common base for EPEX day-ahead sensors.
+
+    The ``_BoundaryScheduleMixin`` arms a point-in-UTC-time callback at
+    the next EPEX slot boundary so both the current-price and
+    next-hour-price sensors update at the exact second the market moves
+    between slots, rather than waiting up to a full coordinator refresh
+    interval. The same boundary serves both: at each hourly transition
+    the current slot becomes the previous-hour slot AND the next-hour
+    slot shifts, so a single callback covers every dependent value.
+    """
 
     def __init__(
         self,
@@ -733,6 +744,20 @@ class _EngieBeEpexSensorBase(EngieBeEpexEntity, SensorEntity):
     def available(self) -> bool:
         """Available only when a parsed payload exists for the entry."""
         return super().available and _epex_payload(self.coordinator) is not None
+
+    def _next_boundary(self) -> datetime | None:
+        """
+        Return the next EPEX slot boundary in UTC, or ``None``.
+
+        Shared by the current-price and next-hour-price sensors: at
+        every hourly transition the current slot rolls over AND the
+        next-hour slot shifts, so a single callback at the next slot
+        boundary covers both dependent values.
+        """
+        payload = _epex_payload(self.coordinator)
+        if payload is None:
+            return None
+        return next_epex_slot_boundary(payload, dt_util.utcnow())
 
 
 class EngieBeEpexCurrentSensor(_EngieBeEpexSensorBase):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+from homeassistant.components.binary_sensor import BinarySensorEntity
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Awaitable, Callable, Generator
+
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity import Entity
 
 pytest_plugins = ["pytest_homeassistant_custom_component"]
 
@@ -55,3 +59,35 @@ def pytest_configure(config: pytest.Config) -> None:
         "markers",
         "backfill: test exercises relations-backfill behaviour; do not stub it",
     )
+
+
+@pytest.fixture
+def add_sensor() -> Callable[[HomeAssistant, Entity], Awaitable[None]]:
+    """
+    Bind an entity to ``hass`` and drive ``async_added_to_hass``.
+
+    Used by the boundary-scheduler tests across both binary_sensor and
+    sensor platforms. Avoids spinning up a full config entry / platform
+    pipeline: the scheduler behaviour under test depends only on
+    ``self.hass`` being a real HomeAssistant instance, not on the entity
+    being registered with a platform. The platform stub carries just
+    enough attributes for ``async_write_ha_state`` to render a
+    translation key.
+
+    The fallback ``entity_id`` slug is derived from the entity's class
+    name so binary sensors land under ``binary_sensor.`` and sensors
+    under ``sensor.`` without per-call wiring.
+    """
+
+    async def _add(hass: HomeAssistant, entity: Entity) -> None:
+        entity.hass = hass
+        domain = "binary_sensor" if isinstance(entity, BinarySensorEntity) else "sensor"
+        platform = MagicMock()
+        platform.platform_name = "engie_be"
+        platform.domain = domain
+        entity.platform = platform
+        if entity.entity_id is None:
+            entity.entity_id = f"{domain}.test_{type(entity).__name__.lower()}"
+        await entity.async_added_to_hass()
+
+    return _add

--- a/tests/test_binary_sensor_epex_negative_scheduler.py
+++ b/tests/test_binary_sensor_epex_negative_scheduler.py
@@ -1,0 +1,172 @@
+"""
+Tests for the EPEX-negative binary sensor's boundary scheduler.
+
+Validates that ``EngieBeEpexNegativeSensor`` flips at the exact second
+the market moves to the next hourly slot, instead of waiting for the
+next coordinator refresh (up to 60 min lag).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+from zoneinfo import ZoneInfo
+
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
+
+from custom_components.engie_be.binary_sensor import EngieBeEpexNegativeSensor
+from custom_components.engie_be.const import EPEX_TZ, SUBENTRY_TYPE_BUSINESS_AGREEMENT
+from custom_components.engie_be.data import EpexPayload, EpexSlot
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from homeassistant.core import HomeAssistant
+
+    AddSensor = Callable[[HomeAssistant, object], Awaitable[None]]
+
+_BRUSSELS = ZoneInfo(EPEX_TZ)
+
+
+def _make_slot(*, hour: int, value_eur_per_kwh: float) -> EpexSlot:
+    """Build a 1-hour EpexSlot at 2026-05-04 {hour}:00 Brussels-local."""
+    start = datetime(2026, 5, 4, hour, 0, 0, tzinfo=_BRUSSELS)
+    return EpexSlot(
+        start=start,
+        end=start + timedelta(hours=1),
+        value_eur_per_kwh=value_eur_per_kwh,
+        duration_minutes=60,
+    )
+
+
+def _build_payload(slots: tuple[tuple[int, float], ...]) -> EpexPayload:
+    """Build an EpexPayload from ``(hour, eur_per_kwh)`` tuples."""
+    return EpexPayload(
+        slots=tuple(_make_slot(hour=h, value_eur_per_kwh=v) for h, v in slots),
+        publication_time=None,
+        market_date="2026-05-04",
+    )
+
+
+def _make_subentry() -> MagicMock:
+    """Build a MagicMock ConfigSubentry stub."""
+    subentry = MagicMock()
+    subentry.subentry_id = "sub_test"
+    subentry.subentry_type = SUBENTRY_TYPE_BUSINESS_AGREEMENT
+    subentry.title = "Test Account"
+    subentry.data = {}
+    return subentry
+
+
+def _make_coordinator(payload: EpexPayload | None) -> MagicMock:
+    """Build a MagicMock EngieBeEpexCoordinator stub."""
+    coordinator = MagicMock()
+    coordinator.data = payload
+    coordinator.last_update_success = True
+    coordinator.last_successful_fetch = None
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.entry_id = "test_entry_id"
+    return coordinator
+
+
+# Two adjacent slots: 14:00 negative, 15:00 non-negative.
+_PAYLOAD = _build_payload(((14, -0.012), (15, 0.087)))
+# 14:00 Brussels (= 12:00 UTC) is the start of the first slot, 15:00
+# Brussels (= 13:00 UTC) is the boundary at which the sign should flip.
+_NEG_SLOT_START_UTC = datetime(2026, 5, 4, 12, 0, tzinfo=UTC)
+_BOUNDARY_UTC = datetime(2026, 5, 4, 13, 0, tzinfo=UTC)
+
+
+async def test_scheduler_arms_at_next_slot_boundary(
+    hass: HomeAssistant,
+    add_sensor: AddSensor,
+) -> None:
+    """Inside the negative slot, timer arms at the slot end."""
+    coordinator = _make_coordinator(_PAYLOAD)
+    sensor = EngieBeEpexNegativeSensor(coordinator, _make_subentry())
+    inside = _NEG_SLOT_START_UTC + timedelta(minutes=30)
+    with patch(
+        "custom_components.engie_be.binary_sensor.dt_util.utcnow",
+        return_value=inside,
+    ):
+        await add_sensor(hass, sensor)
+        assert sensor.is_on is True
+        assert sensor._unsub_boundary is not None
+    # Fire the boundary; sensor flips to off and a fresh timer arms.
+    with patch(
+        "custom_components.engie_be.binary_sensor.dt_util.utcnow",
+        return_value=_BOUNDARY_UTC,
+    ):
+        async_fire_time_changed(hass, _BOUNDARY_UTC)
+        await hass.async_block_till_done()
+        assert sensor.is_on is False
+        assert sensor._unsub_boundary is not None
+
+
+async def test_scheduler_does_not_arm_when_payload_missing(
+    hass: HomeAssistant,
+    add_sensor: AddSensor,
+) -> None:
+    """No payload cached: nothing to schedule against."""
+    coordinator = _make_coordinator(None)
+    sensor = EngieBeEpexNegativeSensor(coordinator, _make_subentry())
+    await add_sensor(hass, sensor)
+    assert sensor._unsub_boundary is None
+
+
+async def test_scheduler_does_not_arm_when_payload_in_past(
+    hass: HomeAssistant,
+    add_sensor: AddSensor,
+) -> None:
+    """Cached payload whose slots are all in the past: no timer armed."""
+    coordinator = _make_coordinator(_PAYLOAD)
+    sensor = EngieBeEpexNegativeSensor(coordinator, _make_subentry())
+    future = _BOUNDARY_UTC + timedelta(hours=2)
+    with patch(
+        "custom_components.engie_be.binary_sensor.dt_util.utcnow",
+        return_value=future,
+    ):
+        await add_sensor(hass, sensor)
+        assert sensor._unsub_boundary is None
+
+
+async def test_coordinator_update_rearms_on_new_payload(
+    hass: HomeAssistant,
+    add_sensor: AddSensor,
+) -> None:
+    """A coordinator refresh swaps the timer to the new slot boundary."""
+    coordinator = _make_coordinator(_PAYLOAD)
+    sensor = EngieBeEpexNegativeSensor(coordinator, _make_subentry())
+    inside = _NEG_SLOT_START_UTC + timedelta(minutes=30)
+    with patch(
+        "custom_components.engie_be.binary_sensor.dt_util.utcnow",
+        return_value=inside,
+    ):
+        await add_sensor(hass, sensor)
+        old_unsub = sensor._unsub_boundary
+        assert old_unsub is not None
+        # Same payload, simulated CoordinatorEntity update: timer must
+        # be replaced (not stacked) even when the boundary is unchanged.
+        sensor._handle_coordinator_update()
+        new_unsub = sensor._unsub_boundary
+        assert new_unsub is not None
+        assert new_unsub is not old_unsub
+
+
+async def test_remove_cancels_pending_timer(
+    hass: HomeAssistant,
+    add_sensor: AddSensor,
+) -> None:
+    """Removing the entity cancels its pending boundary timer."""
+    coordinator = _make_coordinator(_PAYLOAD)
+    sensor = EngieBeEpexNegativeSensor(coordinator, _make_subentry())
+    inside = _NEG_SLOT_START_UTC + timedelta(minutes=30)
+    with patch(
+        "custom_components.engie_be.binary_sensor.dt_util.utcnow",
+        return_value=inside,
+    ):
+        await add_sensor(hass, sensor)
+        assert sensor._unsub_boundary is not None
+        sensor._call_on_remove_callbacks()
+        assert sensor._unsub_boundary is None

--- a/tests/test_binary_sensor_happy_hour.py
+++ b/tests/test_binary_sensor_happy_hour.py
@@ -2,14 +2,24 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
+
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
 from custom_components.engie_be.binary_sensor import (
     HAPPY_HOUR_ACTIVE_SENSOR_DESCRIPTION,
     EngieBeHappyHourActiveSensor,
 )
 from custom_components.engie_be.const import SUBENTRY_TYPE_BUSINESS_AGREEMENT
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from homeassistant.core import HomeAssistant
+
+    AddSensor = Callable[[HomeAssistant, object], Awaitable[None]]
 
 # Anchor inside the canonical 12:00-15:00 +02:00 happy-hour window.
 _NOW_INSIDE = datetime(2026, 5, 23, 11, 30, tzinfo=UTC)
@@ -133,3 +143,165 @@ def test_is_on_returns_bool_not_none() -> None:
     with _patched_now(_NOW_INSIDE):
         result = sensor.is_on
     assert isinstance(result, bool)
+
+
+# ---------------------------------------------------------------------------
+# Instant-flip scheduler
+#
+# These tests exercise the point-in-time scheduler that makes the sensor
+# flip on/off at the exact second the Happy Hour window starts or ends,
+# instead of waiting up to a full coordinator refresh interval.
+# ---------------------------------------------------------------------------
+
+# Canonical window used by the scheduler tests, anchored well into the
+# future so freeze-time math is unambiguous regardless of when the suite
+# runs. Both timestamps carry an explicit +02:00 offset (matching the
+# real ENGIE payload shape) so ``happy_hour_window`` returns tz-aware
+# datetimes.
+_FUTURE_PAYLOAD = {
+    "tomorrow": {
+        "startTime": "2099-06-15T12:00:00+02:00",
+        "endTime": "2099-06-15T15:00:00+02:00",
+    },
+}
+# Same window as UTC datetimes for assertions / time travel.
+_FUTURE_START_UTC = datetime(2099, 6, 15, 10, 0, tzinfo=UTC)
+_FUTURE_END_UTC = datetime(2099, 6, 15, 13, 0, tzinfo=UTC)
+# An alternative window that starts earlier; used for the reschedule test.
+_ALT_PAYLOAD = {
+    "tomorrow": {
+        "startTime": "2099-06-15T11:00:00+02:00",
+        "endTime": "2099-06-15T14:00:00+02:00",
+    },
+}
+_ALT_START_UTC = datetime(2099, 6, 15, 9, 0, tzinfo=UTC)
+
+
+async def test_scheduler_arms_at_start_when_now_before_window(
+    hass: HomeAssistant,
+    add_sensor: AddSensor,
+) -> None:
+    """Before the window: timer must be armed; firing it flips to ``on``."""
+    coordinator = _make_coordinator(_wrap(_FUTURE_PAYLOAD))
+    sensor = EngieBeHappyHourActiveSensor(coordinator, _make_subentry())
+    before = _FUTURE_START_UTC - timedelta(minutes=5)
+    with patch(
+        "custom_components.engie_be.binary_sensor.dt_util.utcnow",
+        return_value=before,
+    ):
+        await add_sensor(hass, sensor)
+        assert sensor.is_on is False
+        assert sensor._unsub_boundary is not None
+    # Fire the start boundary; sensor should now be on and a new
+    # timer should be armed for the end boundary.
+    with patch(
+        "custom_components.engie_be.binary_sensor.dt_util.utcnow",
+        return_value=_FUTURE_START_UTC,
+    ):
+        async_fire_time_changed(hass, _FUTURE_START_UTC)
+        await hass.async_block_till_done()
+        assert sensor.is_on is True
+        assert sensor._unsub_boundary is not None
+
+
+async def test_scheduler_arms_at_end_when_now_inside_window(
+    hass: HomeAssistant,
+    add_sensor: AddSensor,
+) -> None:
+    """Inside the window: timer arms at end; firing it flips to ``off``."""
+    coordinator = _make_coordinator(_wrap(_FUTURE_PAYLOAD))
+    sensor = EngieBeHappyHourActiveSensor(coordinator, _make_subentry())
+    inside = _FUTURE_START_UTC + timedelta(minutes=30)
+    with patch(
+        "custom_components.engie_be.binary_sensor.dt_util.utcnow",
+        return_value=inside,
+    ):
+        await add_sensor(hass, sensor)
+        assert sensor.is_on is True
+        assert sensor._unsub_boundary is not None
+    # Fire the end boundary; sensor should now be off and no further
+    # timer should be armed (window is exhausted).
+    with patch(
+        "custom_components.engie_be.binary_sensor.dt_util.utcnow",
+        return_value=_FUTURE_END_UTC,
+    ):
+        async_fire_time_changed(hass, _FUTURE_END_UTC)
+        await hass.async_block_till_done()
+        assert sensor.is_on is False
+        assert sensor._unsub_boundary is None
+
+
+async def test_scheduler_does_not_arm_when_window_already_passed(
+    hass: HomeAssistant,
+    add_sensor: AddSensor,
+) -> None:
+    """A payload whose window is entirely in the past arms no timer."""
+    coordinator = _make_coordinator(_wrap(_FUTURE_PAYLOAD))
+    sensor = EngieBeHappyHourActiveSensor(coordinator, _make_subentry())
+    past = _FUTURE_END_UTC + timedelta(hours=1)
+    with patch(
+        "custom_components.engie_be.binary_sensor.dt_util.utcnow",
+        return_value=past,
+    ):
+        await add_sensor(hass, sensor)
+        assert sensor.is_on is False
+        assert sensor._unsub_boundary is None
+
+
+async def test_scheduler_does_not_arm_when_payload_empty(
+    hass: HomeAssistant,
+    add_sensor: AddSensor,
+) -> None:
+    """No scheduled window: no timer armed; sensor is off."""
+    coordinator = _make_coordinator(_wrap({}))
+    sensor = EngieBeHappyHourActiveSensor(coordinator, _make_subentry())
+    await add_sensor(hass, sensor)
+    assert sensor.is_on is False
+    assert sensor._unsub_boundary is None
+
+
+async def test_coordinator_update_reschedules_to_new_window(
+    hass: HomeAssistant,
+    add_sensor: AddSensor,
+) -> None:
+    """A payload swap must cancel the existing timer and arm a fresh one."""
+    coordinator = _make_coordinator(_wrap(_FUTURE_PAYLOAD))
+    sensor = EngieBeHappyHourActiveSensor(coordinator, _make_subentry())
+    before = _ALT_START_UTC - timedelta(minutes=5)
+    with patch(
+        "custom_components.engie_be.binary_sensor.dt_util.utcnow",
+        return_value=before,
+    ):
+        await add_sensor(hass, sensor)
+        old_unsub = sensor._unsub_boundary
+        assert old_unsub is not None
+        # Swap to an earlier-starting window and notify the entity as a
+        # CoordinatorEntity would on the next refresh.
+        coordinator.data = _wrap(_ALT_PAYLOAD)
+        sensor._handle_coordinator_update()
+        new_unsub = sensor._unsub_boundary
+        assert new_unsub is not None
+        # Re-arming must replace the unsub handle, not stack a second one.
+        assert new_unsub is not old_unsub
+
+
+async def test_remove_cancels_pending_timer(
+    hass: HomeAssistant,
+    add_sensor: AddSensor,
+) -> None:
+    """Removing the entity cancels its pending boundary timer."""
+    coordinator = _make_coordinator(_wrap(_FUTURE_PAYLOAD))
+    sensor = EngieBeHappyHourActiveSensor(coordinator, _make_subentry())
+    before = _FUTURE_START_UTC - timedelta(minutes=5)
+    with patch(
+        "custom_components.engie_be.binary_sensor.dt_util.utcnow",
+        return_value=before,
+    ):
+        await add_sensor(hass, sensor)
+        assert sensor._unsub_boundary is not None
+        # The cancel is registered via ``self.async_on_remove`` and runs
+        # in ``_call_on_remove_callbacks``; firing those directly avoids
+        # the full ``async_remove`` path which requires the entity to be
+        # registered in ``entity_sources``.
+        sensor._call_on_remove_callbacks()
+        assert sensor._unsub_boundary is None

--- a/tests/test_epex_helpers.py
+++ b/tests/test_epex_helpers.py
@@ -1,0 +1,96 @@
+"""Unit tests for the pure EPEX slot-boundary helper."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from custom_components.engie_be._epex import next_epex_slot_boundary
+from custom_components.engie_be.data import EpexPayload, EpexSlot
+
+
+def _slot(
+    start: datetime, *, duration_minutes: int = 60, value: float = 0.05
+) -> EpexSlot:
+    """Build a single contiguous EpexSlot starting at ``start``."""
+    return EpexSlot(
+        start=start,
+        end=start + timedelta(minutes=duration_minutes),
+        value_eur_per_kwh=value,
+        duration_minutes=duration_minutes,
+    )
+
+
+def _payload(slots: tuple[EpexSlot, ...]) -> EpexPayload:
+    """Wrap slots into an EpexPayload with empty publication metadata."""
+    return EpexPayload(slots=slots, publication_time=None, market_date=None)
+
+
+def test_returns_none_when_payload_is_none() -> None:
+    """A missing payload yields no boundary."""
+    now = datetime(2026, 5, 4, 12, 30, tzinfo=UTC)
+    assert next_epex_slot_boundary(None, now) is None
+
+
+def test_returns_none_for_empty_slot_tuple() -> None:
+    """An EpexPayload with no slots yields no boundary."""
+    now = datetime(2026, 5, 4, 12, 30, tzinfo=UTC)
+    assert next_epex_slot_boundary(_payload(()), now) is None
+
+
+def test_returns_slot_end_when_now_inside_slot() -> None:
+    """When ``now`` sits inside a slot, the boundary is that slot's end."""
+    start = datetime(2026, 5, 4, 12, 0, tzinfo=UTC)
+    payload = _payload((_slot(start),))
+    now = datetime(2026, 5, 4, 12, 30, tzinfo=UTC)
+    assert next_epex_slot_boundary(payload, now) == start + timedelta(hours=1)
+
+
+def test_returns_next_slot_start_when_now_before_first_slot() -> None:
+    """When ``now`` precedes every slot, the boundary is the earliest start."""
+    earliest = datetime(2026, 5, 4, 12, 0, tzinfo=UTC)
+    later = datetime(2026, 5, 4, 13, 0, tzinfo=UTC)
+    payload = _payload((_slot(earliest), _slot(later)))
+    now = datetime(2026, 5, 4, 11, 30, tzinfo=UTC)
+    assert next_epex_slot_boundary(payload, now) == earliest
+
+
+def test_handles_gap_between_slots() -> None:
+    """A gap between slots is fine: the next-start candidate wins."""
+    covering = datetime(2026, 5, 4, 12, 0, tzinfo=UTC)
+    after_gap = datetime(2026, 5, 4, 14, 0, tzinfo=UTC)
+    payload = _payload((_slot(covering), _slot(after_gap)))
+    now = datetime(2026, 5, 4, 13, 30, tzinfo=UTC)
+    # No slot covers 13:30 (gap 13:00..14:00); next boundary is 14:00 start.
+    assert next_epex_slot_boundary(payload, now) == after_gap
+
+
+def test_returns_none_when_every_slot_is_in_the_past() -> None:
+    """If every slot ends at or before ``now``, no future boundary exists."""
+    start = datetime(2026, 5, 4, 10, 0, tzinfo=UTC)
+    payload = _payload((_slot(start),))
+    now = datetime(2026, 5, 4, 12, 0, tzinfo=UTC)
+    assert next_epex_slot_boundary(payload, now) is None
+
+
+def test_exact_boundary_treated_as_start_of_next_slot() -> None:
+    """
+    At a slot start instant, that slot covers ``now`` (closed-open).
+
+    The boundary should then be the end of that slot, not the start.
+    """
+    start = datetime(2026, 5, 4, 12, 0, tzinfo=UTC)
+    payload = _payload((_slot(start),))
+    now = start  # slot.start <= now < slot.end is True at the boundary
+    assert next_epex_slot_boundary(payload, now) == start + timedelta(hours=1)
+
+
+def test_picks_earliest_candidate_with_contiguous_slots() -> None:
+    """With contiguous slots, slot.end == next slot.start; min() is stable."""
+    s1 = datetime(2026, 5, 4, 12, 0, tzinfo=UTC)
+    s2 = datetime(2026, 5, 4, 13, 0, tzinfo=UTC)
+    s3 = datetime(2026, 5, 4, 14, 0, tzinfo=UTC)
+    payload = _payload((_slot(s1), _slot(s2), _slot(s3)))
+    now = datetime(2026, 5, 4, 12, 30, tzinfo=UTC)
+    # slot1.end == s2; slot2.start == s2; slot3.start == s3.
+    # Earliest candidate is s2.
+    assert next_epex_slot_boundary(payload, now) == s2

--- a/tests/test_sensor_epex_schedulers.py
+++ b/tests/test_sensor_epex_schedulers.py
@@ -1,0 +1,193 @@
+"""
+Tests for the EPEX current-price + next-hour sensor boundary scheduler.
+
+Validates that ``EngieBeEpexCurrentSensor`` and
+``EngieBeEpexNextHourSensor`` both rearm via the shared
+``_BoundaryScheduleMixin`` so their values shift at the exact second
+the market moves between hourly slots.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+from zoneinfo import ZoneInfo
+
+import pytest
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
+
+from custom_components.engie_be import sensor as sensor_module
+from custom_components.engie_be.const import EPEX_TZ, SUBENTRY_TYPE_BUSINESS_AGREEMENT
+from custom_components.engie_be.data import EpexPayload, EpexSlot
+from custom_components.engie_be.sensor import (
+    EngieBeEpexCurrentSensor,
+    EngieBeEpexNextHourSensor,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from homeassistant.core import HomeAssistant
+
+    AddSensor = Callable[[HomeAssistant, object], Awaitable[None]]
+
+_EPEX_CURRENT_DESC = sensor_module._EPEX_CURRENT
+_EPEX_NEXT_HOUR_DESC = sensor_module._EPEX_NEXT_HOUR
+
+_BRUSSELS = ZoneInfo(EPEX_TZ)
+
+
+def _make_slot(*, hour: int, value_eur_per_kwh: float) -> EpexSlot:
+    """Build a 1-hour EpexSlot at 2026-05-04 {hour}:00 Brussels-local."""
+    start = datetime(2026, 5, 4, hour, 0, 0, tzinfo=_BRUSSELS)
+    return EpexSlot(
+        start=start,
+        end=start + timedelta(hours=1),
+        value_eur_per_kwh=value_eur_per_kwh,
+        duration_minutes=60,
+    )
+
+
+def _build_payload(slots: tuple[tuple[int, float], ...]) -> EpexPayload:
+    """Build an EpexPayload from ``(hour, eur_per_kwh)`` tuples."""
+    return EpexPayload(
+        slots=tuple(_make_slot(hour=h, value_eur_per_kwh=v) for h, v in slots),
+        publication_time=None,
+        market_date="2026-05-04",
+    )
+
+
+def _make_subentry() -> MagicMock:
+    """Build a MagicMock ConfigSubentry stub."""
+    subentry = MagicMock()
+    subentry.subentry_id = "sub_test"
+    subentry.subentry_type = SUBENTRY_TYPE_BUSINESS_AGREEMENT
+    subentry.title = "Test Account"
+    subentry.data = {}
+    return subentry
+
+
+def _make_coordinator(payload: EpexPayload | None) -> MagicMock:
+    """Build a MagicMock EngieBeEpexCoordinator stub."""
+    coordinator = MagicMock()
+    coordinator.data = payload
+    coordinator.last_update_success = True
+    coordinator.last_update_success_time = None
+    coordinator.last_successful_fetch = None
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.entry_id = "test_entry_id"
+    return coordinator
+
+
+# Three adjacent slots so next-hour has a value to read at 14:30.
+_PAYLOAD = _build_payload(((14, 0.071), (15, 0.124), (16, 0.098)))
+_SLOT_14_START_UTC = datetime(2026, 5, 4, 12, 0, tzinfo=UTC)  # 14:00 Brussels
+_BOUNDARY_UTC = datetime(2026, 5, 4, 13, 0, tzinfo=UTC)  # 15:00 Brussels
+
+
+def _current_sensor(coordinator: MagicMock) -> EngieBeEpexCurrentSensor:
+    """Build a current-price sensor with the live descriptor."""
+    return EngieBeEpexCurrentSensor(coordinator, _make_subentry(), _EPEX_CURRENT_DESC)
+
+
+def _next_hour_sensor(coordinator: MagicMock) -> EngieBeEpexNextHourSensor:
+    """Build a next-hour sensor with the live descriptor."""
+    return EngieBeEpexNextHourSensor(
+        coordinator, _make_subentry(), _EPEX_NEXT_HOUR_DESC
+    )
+
+
+async def test_current_sensor_flips_at_slot_boundary(
+    hass: HomeAssistant,
+    add_sensor: AddSensor,
+) -> None:
+    """Current-price sensor rolls to the next slot at the boundary."""
+    coordinator = _make_coordinator(_PAYLOAD)
+    sensor = _current_sensor(coordinator)
+    inside = _SLOT_14_START_UTC + timedelta(minutes=30)
+    with patch(
+        "custom_components.engie_be.sensor.dt_util.utcnow",
+        return_value=inside,
+    ):
+        await add_sensor(hass, sensor)
+        assert sensor.native_value == pytest.approx(0.071)
+        assert sensor._unsub_boundary is not None
+    with patch(
+        "custom_components.engie_be.sensor.dt_util.utcnow",
+        return_value=_BOUNDARY_UTC,
+    ):
+        async_fire_time_changed(hass, _BOUNDARY_UTC)
+        await hass.async_block_till_done()
+        assert sensor.native_value == pytest.approx(0.124)
+        assert sensor._unsub_boundary is not None
+
+
+async def test_next_hour_sensor_flips_at_slot_boundary(
+    hass: HomeAssistant,
+    add_sensor: AddSensor,
+) -> None:
+    """Next-hour sensor advances one slot forward at the boundary."""
+    coordinator = _make_coordinator(_PAYLOAD)
+    sensor = _next_hour_sensor(coordinator)
+    inside = _SLOT_14_START_UTC + timedelta(minutes=30)
+    with patch(
+        "custom_components.engie_be.sensor.dt_util.utcnow",
+        return_value=inside,
+    ):
+        await add_sensor(hass, sensor)
+        assert sensor.native_value == pytest.approx(0.124)
+        assert sensor._unsub_boundary is not None
+    with patch(
+        "custom_components.engie_be.sensor.dt_util.utcnow",
+        return_value=_BOUNDARY_UTC,
+    ):
+        async_fire_time_changed(hass, _BOUNDARY_UTC)
+        await hass.async_block_till_done()
+        assert sensor.native_value == pytest.approx(0.098)
+        assert sensor._unsub_boundary is not None
+
+
+async def test_scheduler_does_not_arm_when_payload_missing(
+    hass: HomeAssistant,
+    add_sensor: AddSensor,
+) -> None:
+    """No cached payload: nothing to schedule against."""
+    coordinator = _make_coordinator(None)
+    sensor = _current_sensor(coordinator)
+    await add_sensor(hass, sensor)
+    assert sensor._unsub_boundary is None
+
+
+async def test_scheduler_does_not_arm_when_payload_in_past(
+    hass: HomeAssistant,
+    add_sensor: AddSensor,
+) -> None:
+    """Cached payload whose slots are all in the past: no timer armed."""
+    coordinator = _make_coordinator(_PAYLOAD)
+    sensor = _current_sensor(coordinator)
+    future = _BOUNDARY_UTC + timedelta(hours=10)
+    with patch(
+        "custom_components.engie_be.sensor.dt_util.utcnow",
+        return_value=future,
+    ):
+        await add_sensor(hass, sensor)
+        assert sensor._unsub_boundary is None
+
+
+async def test_remove_cancels_pending_timer(
+    hass: HomeAssistant,
+    add_sensor: AddSensor,
+) -> None:
+    """Removing the entity cancels its pending boundary timer."""
+    coordinator = _make_coordinator(_PAYLOAD)
+    sensor = _next_hour_sensor(coordinator)
+    inside = _SLOT_14_START_UTC + timedelta(minutes=30)
+    with patch(
+        "custom_components.engie_be.sensor.dt_util.utcnow",
+        return_value=inside,
+    ):
+        await add_sensor(hass, sensor)
+        assert sensor._unsub_boundary is not None
+        sensor._call_on_remove_callbacks()
+        assert sensor._unsub_boundary is None


### PR DESCRIPTION
Closes the second half of #25.

## Summary

Adds a shared `_BoundaryScheduleMixin` that schedules a precise point-in-UTC-time callback at the next state-change instant for four time-window-driven entities:

- `binary_sensor.*_happy_hour_active`
- `binary_sensor.*_epex_negative_now`
- `sensor.*_epex_current`
- `sensor.*_epex_next_hour`

Previously these only refreshed when the coordinator next polled, so on/off and value transitions could lag by up to a full refresh interval (default 60 minutes for EPEX). The mixin mirrors the pattern used by HA core's `binary_sensor.tod` integration and re-arms itself on every fire.

## Implementation notes

- New `_epex.py` helper exposes `next_epex_slot_boundary(payload, now)` so the sensor and binary-sensor sides share one boundary algorithm.
- `_BoundaryScheduleMixin` lives on `entity.py` and is prepended to the MRO of each affected entity (above the coordinator base) so `super().async_added_to_hass()` and `super()._handle_coordinator_update()` chain correctly.
- Mixin no-ops when `_next_boundary` returns `None` (payload not yet available) or a timestamp that already elapsed (defensive against `utcnow` races).
- Bumps `manifest.json` to `0.10.0b2`.

## Live verification

Verified end-to-end against a dev HA instance: `_boundary_fired` ran at `16:00:00.001-006` for all 5 EPEX entities and wrote the new slot's value (`-0.00029`) within the first 5 ms of the new market slot. Post-reload, the state machine and history reflect the boundary-fired value with `last_changed` matching the slot boundary.

## Tests

- `tests/test_epex_helpers.py` covers `next_epex_slot_boundary` (empty payload, slot in past, mid-slot, edge of slot).
- `tests/test_binary_sensor_epex_negative_scheduler.py` and `tests/test_sensor_epex_schedulers.py` exercise arm + fire + re-arm for the three EPEX entities.
- `tests/test_binary_sensor_happy_hour.py` extended for the happy-hour scheduler.
- New `add_sensor` fixture in `tests/conftest.py` for setting up individual sensor entities under test.

`pytest --cov=custom_components.engie_be --cov-fail-under=85`: **445 passed, coverage 90.18%** (entity.py 97%, binary_sensor.py 98%, sensor.py 100%, _epex.py 100%, coordinator.py 100%). Lint clean.